### PR TITLE
Extract obserable type and value from (simple) indicator pattern during import of Indicator

### DIFF
--- a/pycti/opencti_stix2.py
+++ b/pycti/opencti_stix2.py
@@ -914,7 +914,7 @@ class OpenCTIStix2:
                 if object_type in stix2.OBJ_MAP_OBSERVABLE:
 
                     # get the left hand side as string and use it for looking up the correct OpenCTI name
-                    lhs = str(pattern.operand.lhs)
+                    lhs = str(pattern.operand.lhs)  # this is "file:hashes.md5" from the reference pattern
                     if lhs in STIX2OPENCTI:
                         # the type and value can now be set
                         indicator_type = STIX2OPENCTI[lhs]


### PR DESCRIPTION
This uses the stix2 lib to read the indicator pattern, and extract the type and value, such that STIX indicators without 'x_opencti_observable_type' and 'x_opencti_observable_value' can be handled.

There are two main issues:
  1. I don't think the new STIX2OPENCTI mapping contains all the observable types, so not everything can be imported using this.
  2. The extraction only works if there is exactly one STIX Pattern 'Comparison Expression' in the pattern, so this won't work for more complex indicator patterns.

EDIT: this might be related to https://github.com/OpenCTI-Platform/opencti/issues/141?