### PR TITLE
new: [AMITT] add AMITT technique id parsing

### DIFF
--- a/pycti/entities/opencti_attack_pattern.py
+++ b/pycti/entities/opencti_attack_pattern.py
@@ -304,14 +304,15 @@ class AttackPattern:
             if 'external_references' in stix_object:
                 for external_reference in stix_object['external_references']:
                     if external_reference['source_name'] == 'mitre-attack' or external_reference[
-                        'source_name'] == 'mitre-pre-attack':
+                        'source_name'] == 'mitre-pre-attack' or external_reference['source_name'] == 'amitt-attack':
                         external_id = external_reference['external_id']
             return self.create(
                 name=stix_object['name'],
                 description=self.opencti.stix2.convert_markdown(
                     stix_object['description']) if 'description' in stix_object else '',
                 alias=self.opencti.stix2.pick_aliases(stix_object),
-                platform=stix_object['x_mitre_platforms'] if 'x_mitre_platforms' in stix_object else None,
+                platform=stix_object['x_mitre_platforms'] if 'x_mitre_platforms' in stix_object else \
+                    stix_object['x_amitt_platforms'] if 'x_amitt_platforms' in stix_object else None,
                 required_permission=stix_object[
                     'x_mitre_permissions_required'] if 'x_mitre_permissions_required' in stix_object else None,
                 external_id=external_id,

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -79,6 +79,8 @@ class OpenCTIStix2:
             return stix_object[CustomProperties.ALIASES]
         elif 'x_mitre_aliases' in stix_object:
             return stix_object['x_mitre_aliases']
+        elif 'x_amitt_aliases' in stix_object:
+            return stix_object['x_amitt_aliases']
         elif 'aliases' in stix_object:
             return stix_object['aliases']
         return None
@@ -247,6 +249,10 @@ class OpenCTIStix2:
 
                     if 'mitre' in source_name and 'name' in stix_object:
                         title = '[MITRE ATT&CK] ' + stix_object['name']
+                        if 'modified' in stix_object:
+                            published = stix_object['modified']
+                    elif 'amitt' in source_name and 'name' in stix_object:
+                        title = '[AM!TT] ' + stix_object['name']
                         if 'modified' in stix_object:
                             published = stix_object['modified']
                     else:


### PR DESCRIPTION
## Description

AMITT misinformation framework  technique IDs are not rendered on the Techniques page in OpenCTI.  This PR provides required property parsing for AMITT techniques.

## Expected Output

AMITT Technique ID should be listed.

## Actual Output

![2019-12-08_09-18](https://user-images.githubusercontent.com/46228229/70390716-77472d00-199b-11ea-919b-0dbff47397fe.png)
 
## Additional information

AMITT Tactics STIX objects of type `x-amitt-tactic`.
Technique platforms `x-mitre-platforms` has changed to `x-amitt-platforms`.

