### PR TITLE
[Doc] Add sphinx-autodoc-typehints to use Python 3 annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/*.json
 examples/*.pdf
 docs/_build
 Pipfile*
+.mypy_cache/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,12 @@ autoapi_modules = {"pycti": {"prune": True}}
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.inheritance_diagram", "autoapi.sphinx"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.inheritance_diagram",
+    "autoapi.sphinx",
+    "sphinx_autodoc_typehints",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,3 @@
 autoapi>=2.0.1
+sphinx_rtd_theme>=0.4.3
+sphinx-autodoc-typehints>=1.10.3

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -8,27 +8,21 @@ import base64
 import uuid
 import os
 
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Optional, Union
 from pika.exceptions import UnroutableError, NackError
 from pycti.api.opencti_api_client import OpenCTIApiClient
 from pycti.connector.opencti_connector import OpenCTIConnector
 
 
 def get_config_variable(
-    env_var: str, yaml_path: str, config={}, isNumber=False
-) -> Union[str, int]:
+    env_var: str, yaml_path: str, config: Dict = {}, isNumber: Optional[bool] = False
+) -> Union[bool, int, None, str]:
     """[summary]
 
     :param env_var: environnement variable name
-    :type env_var: str
     :param yaml_path: path to yaml config
-    :type yaml_path: str
     :param config: client config dict, defaults to {}
-    :type config: dict, optional
     :param isNumber: specify if the variable is a number, defaults to False
-    :type isNumber: bool, optional
-    :return: either a str or a int variable value
-    :rtype: str or int
     """
 
     if os.getenv(env_var) is not None:

--- a/setup.py
+++ b/setup.py
@@ -62,5 +62,8 @@ setup(
         "python-magic-bin==0.4.14;sys.platform=='win32'",
     ],
     cmdclass={"verify": VerifyVersionCommand},
-    extras_require={"dev": ["black", "wheel"]},  # Optional
+    extras_require={
+        "dev": ["black", "wheel",],
+        "doc": ["autoapi", "sphinx_rtd_theme", "sphinx-autodoc-typehints"],
+    },  # Optional
 )


### PR DESCRIPTION
`sphinx-autodoc-typehints ` allows you to use Python 3 annotations for documenting acceptable argument types and return value types of functions. This allows you to use type hints in a very natural fashion, allowing you to migrate from this:

```py
def format_unit(value, unit):
    """
    Formats the given value as a human readable string using the given units.

    :param float|int value: a numeric value
    :param str unit: the unit for the value (kg, m, etc.)
    :rtype: str
    """
    return '{} {}'.format(value, unit)
```
to this:

```py
from typing import Union

def format_unit(value: Union[float, int], unit: str) -> str:
    """
    Formats the given value as a human readable string using the given units.

    :param value: a numeric value
    :param unit: the unit for the value (kg, m, etc.)
    """
    return '{} {}'.format(value, unit)

```