### PR TITLE
add linked relation in opencti_api_client

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -552,7 +552,8 @@ class OpenCTIApiClient:
             to_type = "stix_relation"
         if relation_type == "related-to":
             return {"from_role": "relate_from", "to_role": "relate_to"}
-
+        if relation_type == "linked":
+            return {"from_role": "link_from", "to_role": "link_to"}
         relation_type = relation_type.lower()
         from_type = from_type.lower()
         from_type = (


### PR DESCRIPTION
This can add linked relationship from client_python which could add by webUI but not api.