### PR TITLE
Revert edit to regain Python3.5 compatibility

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -383,7 +383,7 @@ class OpenCTIConnectorHelper:
             )
             logging.info("Bundle has been sent")
         except (UnroutableError, NackError) as e:
-            logging.error(f"Unable to send bundle, retry...{e}")
+            logging.error("Unable to send bundle, retry...", e)
             self._send_bundle(bundle, entities_types)
 
     def split_stix2_bundle(self, bundle) -> list:


### PR DESCRIPTION
One change in this commit https://github.com/OpenCTI-Platform/client-python/commit/6bc9897594cab95d75f9bc0ff49d268a7262cf8a broke the compatibility with Python3.5.