### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/client_usage/getting_started.rst
+++ b/docs/client_usage/getting_started.rst
@@ -37,7 +37,7 @@ and OpenCTI compatible date format.
         description="This is the C2 server of the campaign",
         pattern_type="stix",
         indicator_pattern="[domain-name:value = 'www.5z8.info']",
-        main_observable_type="IPv4-Addr",
+        x_opencti_main_observable_type="IPv4-Addr",
         valid_from=date,
         update=True,
         markingDefinitions=[TLP_GREEN_CTI["id"]],


### PR DESCRIPTION
main_observable_type should be changed to x_opencti_main_observable_type because if it is not changed, an exception of ERROR:root:[opencti_indicator] Missing parameters: name and pattern and main_observable_type will be thrown because the check which is done under  opencti_indicator.py is not main_observable_type but x_opencti_main_observable_type.