### PR TITLE
Ensure OpenCTIConnectorHelper.get_state always returns a valid state

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -351,13 +351,13 @@ class OpenCTIConnectorHelper:
         """
 
         try:
-            return (
-                None
-                if self.connector_state is None
-                else json.loads(self.connector_state)
-            )
+            if self.connector_state:
+                state = json.loads(self.connector_state)
+                if isinstance(state, dict) and state:
+                    return state
         except:
-            return None
+            pass
+        return None
 
     def listen(self, message_callback: Callable[[str, Dict], str]) -> None:
         """listen for messages and register callback function


### PR DESCRIPTION
I noticed an odd bug with the History Connector earlier. I believe this PR fixes that error.

Here are the logs I have from the connector:

```

INFO:root:Listing Threat-Actors with filters null.
--
INFO:root:Connector registered with ID:<connector-history-id>
INFO:root:Starting ping alive thread
INFO:root:Getting logs worker config...
INFO:root:Starting listening stream events with SSL verify to: True
Traceback (most recent call last):
File "history.py", line 71, in <module>
HistoryInstance.start()
File "history.py", line 66, in start
self.helper.listen_stream(self._process_message)
File "/usr/local/lib/python3.8/site-packages/pycti/connector/opencti_connector_helper.py", line 425, in listen_stream
if current_state["connectorLastEventId"] == last_event_id:
TypeError: string indices must be integers

```

Basically, I managed to get the history connector into a bad state. Restarting the connector / hitting the "Reset Connector State" button in the Web UI were both ineffective in getting the connector functioning again. I _think_ I triggered this condition when I hit the "Reset Connector State" button while running 4.0.6, and then later upgraded to 4.1.1.

The issue is that `get_state()` is expected to either return None or a dictionary containing a `connectorLastEventId` key, but it was returning a string instead. This PR should help the state to self-heal should it ever recur.