### PR TITLE
[connector] Specify SSLContext.minimum_version

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -69,13 +69,11 @@ def create_ssl_context() -> ssl.SSLContext:
         ssl.OP_NO_RENEGOTIATION,  # pylint: disable=no-member
         ssl.OP_SINGLE_DH_USE,
         ssl.OP_SINGLE_ECDH_USE,
-        ssl.OP_NO_SSLv3,
-        ssl.OP_NO_TLSv1,
-        ssl.OP_NO_TLSv1_1,
     ]
     ssl_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
     ssl_context.options &= ~ssl.OP_ENABLE_MIDDLEBOX_COMPAT  # pylint: disable=no-member
     ssl_context.verify_mode = ssl.CERT_REQUIRED
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
 
     for option in ssl_context_options:
         ssl_context.options |= option


### PR DESCRIPTION
OpenSSL has deprecated Protocol Version Options as of OpenSSL 1.1.0. Use
the Python SSL interface for SSL_CTX_set_mini_proto_version() to require
TLSv1.2+.

* https://wiki.openssl.org/index.php/List_of_SSL_OP_Flags#Protocol_Version_Options
* https://docs.python.org/3/library/ssl.html#ssl.OP_NO_TLSv1
