### PR TITLE
[ConnectorHelper] Fixed format type and documentation according to code

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -451,11 +451,11 @@ class OpenCTIConnectorHelper:
             pass
         return None
 
-    def listen(self, message_callback: Callable[[str, Dict], str]) -> None:
+    def listen(self, message_callback: Callable[[Dict], str]) -> None:
         """listen for messages and register callback function
 
         :param message_callback: callback function to process messages
-        :type message_callback: Callable[[Dict], List[str]]
+        :type message_callback: Callable[[Dict], str]
         """
 
         listen_queue = ListenQueue(self, self.config, message_callback)


### PR DESCRIPTION
Adapted the type format and the documentation according to the data type used here:

https://github.com/OpenCTI-Platform/client-python/blob/082c1fc977894e3ce31c13e36074fd8a304f6f0b/pycti/connector/opencti_connector_helper.py#L145