### PR TITLE
[OpenCTIStix2] Fix date bug in format_date

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -69,12 +69,12 @@ class OpenCTIStix2:
             try:
                 date_value = dateutil.parser.parse(date)
             except (dateutil.parser.ParserError, TypeError, OverflowError) as e:
-                raise ValueError(f'{e}: {date} does not contain a valid date string')
+                raise ValueError(f"{e}: {date} does not contain a valid date string")
         else:
             date_value = datetime.datetime.utcnow()
 
         if not date_value.tzinfo:
-            self.opencti.log('No timezone found. Setting to UTC', 'info')
+            self.opencti.log("No timezone found. Setting to UTC", "info")
             date_value = date_value.replace(tzinfo=datetime.timezone.utc)
 
         return date_value.isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -57,9 +57,9 @@ class OpenCTIStix2:
         """converts multiple input date formats to OpenCTI style dates
 
         :param date: input date
-        :type date:
+        :type date: Any [datetime, date, str or none]
         :return: OpenCTI style date
-        :rtype: datetime
+        :rtype: string
         """
         if isinstance(date, datetime.datetime):
             date_value = date
@@ -72,6 +72,10 @@ class OpenCTIStix2:
                 raise ValueError(f'{e}: {date} does not contain a valid date string')
         else:
             date_value = datetime.datetime.utcnow()
+
+        if not date_value.tzinfo:
+            self.opencti.log('No timezone found. Setting to UTC', 'info')
+            date_value = date_value.replace(tzinfo=datetime.timezone.utc)
 
         return date_value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import os
 import uuid
-from typing import List
+from typing import List, Any
 
 import datefinder
 import dateutil.parser
@@ -52,7 +52,7 @@ class OpenCTIStix2:
 
         return text.replace("<code>", "`").replace("</code>", "`")
 
-    def format_date(self, date):
+    def format_date(self, date: Any = None) -> str:
         """converts multiple input date formats to OpenCTI style dates
 
         :param date: input date
@@ -60,21 +60,16 @@ class OpenCTIStix2:
         :return: OpenCTI style date
         :rtype: datetime
         """
-
         if isinstance(date, datetime.datetime):
-            return date.isoformat(timespec="milliseconds").replace("+00:00", "Z")
-        if date is not None:
-            return (
-                dateutil.parser.parse(date)
-                .isoformat(timespec="milliseconds")
-                .replace("+00:00", "Z")
-            )
+            date_value = date
+        elif isinstance(date, datetime.date):
+            date_value = datetime.datetime.combine(date, datetime.datetime.min.time())
+        elif date is not None:
+            date_value = dateutil.parser.parse(date)
         else:
-            return (
-                datetime.datetime.utcnow()
-                .isoformat(timespec="milliseconds")
-                .replace("+00:00", "Z")
-            )
+            date_value = datetime.datetime.utcnow()
+
+        return date_value.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
     def filter_objects(self, uuids: list, objects: list) -> list:
         """filters objects based on UUIDs

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -61,7 +61,7 @@ class OpenCTIStix2:
         :rtype: datetime
         """
 
-        if isinstance(date, datetime.date):
+        if isinstance(date, datetime.datetime):
             return date.isoformat(timespec="milliseconds").replace("+00:00", "Z")
         if date is not None:
             return (

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -65,8 +65,11 @@ class OpenCTIStix2:
             date_value = date
         elif isinstance(date, datetime.date):
             date_value = datetime.datetime.combine(date, datetime.datetime.min.time())
-        elif date is not None:
-            date_value = dateutil.parser.parse(date)
+        elif isinstance(date, str):
+            try:
+                date_value = dateutil.parser.parse(date)
+            except (dateutil.parser.ParserError, TypeError, OverflowError) as e:
+                raise ValueError(f'{e}: {date} does not contain a valid date string')
         else:
             date_value = datetime.datetime.utcnow()
 

--- a/tests/01-unit/test_stix.py
+++ b/tests/01-unit/test_stix.py
@@ -1,0 +1,66 @@
+import datetime
+
+from pycti import OpenCTIApiClient
+from pycti.utils.opencti_stix2 import OpenCTIStix2
+import pytest
+
+
+@pytest.fixture
+def api_client():
+    return OpenCTIApiClient(
+        "https://demo.opencti.io",
+        "681b01f9-542d-4c8c-be0c-b6c850b087c8",
+        ssl_verify=True,
+    )
+
+
+def test_format_date_with_tz(api_client):
+    # Test all 4 format_date cases with timestamp + timezone
+    stix = OpenCTIStix2(api_client)
+    my_datetime = datetime.datetime(
+        2021, 3, 5, 13, 31, 19, 42621, tzinfo=datetime.timezone.utc
+    )
+    my_datetime_str = my_datetime.isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+    assert my_datetime_str == stix.format_date(my_datetime)
+    my_date = my_datetime.date()
+    my_date_str = "2021-03-05T00:00:00.000Z"
+    assert my_date_str == stix.format_date(my_date)
+    assert my_datetime_str == stix.format_date(my_datetime_str)
+    assert (
+        str(
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "")
+        )
+        in stix.format_date()
+    )
+    with pytest.raises(ValueError):
+        stix.format_date("No time")
+
+
+def test_format_date_without_tz(api_client):
+    # Test all 4 format_date cases with timestamp w/o timezone
+    stix = OpenCTIStix2(api_client)
+    my_datetime = datetime.datetime(2021, 3, 5, 13, 31, 19, 42621)
+    my_datetime_str = (
+        my_datetime.replace(tzinfo=datetime.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+    assert my_datetime_str == stix.format_date(my_datetime)
+    my_date = my_datetime.date()
+    my_date_str = "2021-03-05T00:00:00.000Z"
+    assert my_date_str == stix.format_date(my_date)
+    assert my_datetime_str == stix.format_date(my_datetime_str)
+    assert (
+        str(
+            datetime.datetime.now(tz=datetime.timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "")
+        )
+        in stix.format_date()
+    )
+    with pytest.raises(ValueError):
+        stix.format_date("No time")


### PR DESCRIPTION
POC for the date error:

```
opencti_api_client = OpenCTIApiClient(api_url, api_token)
mynow = datetime.now().date()

opencti_api_client.stix2.format_date(mynow)
```
->
> INFO:root:Listing Threat-Actors with filters null.
Traceback (most recent call last):
  File "/home/user/test.py", line 4, in <module>
    opencti_api_client.stix2.format_date(mynow)
  File "/home/user/client-python/venv/lib/python3.9/site-packages/pycti/utils/opencti_stix2.py", line 65, in format_date
    return date.isoformat(timespec="milliseconds").replace("+00:00", "Z")
TypeError: date.isoformat() takes no keyword arguments

I also converted some type hints to the old approach and did my best to add type hints to all other functions. I couldn't add one type hint to the init function, since the import of OpenCTIApiClient would have created a circular import.

I also added a few test cases for the format_date function
