### PR TITLE
Add JSON format and timestamp for logs

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -3,9 +3,7 @@ import datetime
 import io
 import json
 import logging
-import os
 from typing import Union
-import sys
 
 import magic
 from pythonjsonlogger import jsonlogger
@@ -55,14 +53,14 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 class CustomJsonFormatter(jsonlogger.JsonFormatter):
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
-        if not log_record.get('timestamp'):
+        if not log_record.get("timestamp"):
             # This doesn't use record.created, so it is slightly off
-            now = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-            log_record['timestamp'] = now
-        if log_record.get('level'):
-            log_record['level'] = log_record['level'].upper()
+            now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            log_record["timestamp"] = now
+        if log_record.get("level"):
+            log_record["level"] = log_record["level"].upper()
         else:
-            log_record['level'] = record.levelname
+            log_record["level"] = record.levelname
 
 
 class File:
@@ -91,9 +89,19 @@ class OpenCTIApiClient:
             "https: "http://my_proxy:8080"
         }
         ```
+    :param json_logging: format the logs as json if set to True
+    :type json_logging: bool, optional
     """
 
-    def __init__(self, url, token, log_level="info", ssl_verify=False, proxies={}):
+    def __init__(
+        self,
+        url,
+        token,
+        log_level="info",
+        ssl_verify=False,
+        proxies={},
+        json_logging=False,
+    ):
         """Constructor method"""
 
         # Check configuration
@@ -110,10 +118,12 @@ class OpenCTIApiClient:
         if not isinstance(numeric_level, int):
             raise ValueError("Invalid log level: " + self.log_level)
 
-        if bool(os.getenv("OPENCTI_JSON_LOGGING", "False").lower() == "true"):
+        if json_logging:
             log_handler = logging.StreamHandler()
             log_handler.setLevel(self.log_level.upper())
-            formatter = CustomJsonFormatter('%(timestamp)s %(level)s %(name)s %(message)s')
+            formatter = CustomJsonFormatter(
+                "%(timestamp)s %(level)s %(name)s %(message)s"
+            )
             log_handler.setFormatter(formatter)
             logging.basicConfig(handlers=[log_handler], level=numeric_level, force=True)
         else:

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -381,6 +381,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         self.opencti_ssl_verify = get_config_variable(
             "OPENCTI_SSL_VERIFY", ["opencti", "ssl_verify"], config, False, True
         )
+        self.opencti_json_logging = get_config_variable(
+            "OPENCTI_JSON_LOGGING", ["opencti", "json_logging"], config
+        )
         # Load connector config
         self.connect_id = get_config_variable(
             "CONNECTOR_ID", ["connector", "id"], config
@@ -438,7 +441,10 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
 
         # Initialize configuration
         self.api = OpenCTIApiClient(
-            self.opencti_url, self.opencti_token, self.log_level
+            self.opencti_url,
+            self.opencti_token,
+            self.log_level,
+            json_logging=self.opencti_json_logging,
         )
         # Register the connector in OpenCTI
         self.connector = OpenCTIConnector(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ datefinder~=0.7
 stix2~=2.1.0
 pika~=1.2
 sseclient~=0.0.27
-python_json_logger==2.0.2
+python_json_logger~=2.0.2
 python-magic~=0.4.24; sys_platform == 'linux' or sys_platform == 'darwin'
 python-magic-bin~=0.4.24; sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ datefinder~=0.7
 stix2~=2.1.0
 pika~=1.2
 sseclient~=0.0.27
+python_json_logger==2.0.2
 python-magic~=0.4.24; sys_platform == 'linux' or sys_platform == 'darwin'
 python-magic-bin~=0.4.24; sys_platform == 'win32'

--- a/tests/cases/connectors.py
+++ b/tests/cases/connectors.py
@@ -60,6 +60,7 @@ class ExternalImportConnector:
         os.environ["OPENCTI_URL"] = api_client.api_url
         os.environ["OPENCTI_TOKEN"] = api_client.api_token
         os.environ["OPENCTI_SSL_VERIFY"] = str(api_client.ssl_verify)
+        os.environ["OPENCTI_JSON_LOGGING"] = "true"
 
         config = (
             yaml.load(open(config_file_path), Loader=yaml.FullLoader)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the option to have a JSON format for the logs if the environment variable `OPENCTI_JSON_LOGGING` is set to True.  This adds a new dependency: `python_json_logger`.
* Add a timestamp, using a custom Formatter, in the logs to facilitate the reading.

Example of output: 

```
{"timestamp": "2021-09-15T09:34:43.106091Z", "level": "INFO", "name": "root", "message": "Listing Threat-Actors with filters null."}
{"timestamp": "2021-09-15T09:34:43.116402Z", "level": "DEBUG", "name": "urllib3.connectionpool", "message": "Starting new HTTP connection (1): opencti:8080"}
```

### Related issues

* #207 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

This is the current workaround I use to have the logs in JSON format, but maybe you have a cleaner solution or a better alternative to propose. 

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
