### PR TITLE
[client] add initialization of prometheus metrics in helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sseclient~=0.0.27
 python_json_logger~=2.0.2
 python-magic~=0.4.24; sys_platform == 'linux' or sys_platform == 'darwin'
 python-magic-bin~=0.4.14; sys_platform == 'win32'
+prometheus-client~=0.11.0

--- a/tests/cases/connectors.py
+++ b/tests/cases/connectors.py
@@ -61,6 +61,8 @@ class ExternalImportConnector:
         os.environ["OPENCTI_TOKEN"] = api_client.api_token
         os.environ["OPENCTI_SSL_VERIFY"] = str(api_client.ssl_verify)
         os.environ["OPENCTI_JSON_LOGGING"] = "true"
+        os.environ["CONNECTOR_EXPOSE_METRICS"] = "true"
+        os.environ["CONNECTOR_METRICS_PORT"] = "9096"
 
         config = (
             yaml.load(open(config_file_path), Loader=yaml.FullLoader)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Initialize prometheus metrics in the `OpenCTIConnectorHelper` class if the `CONNECTOR_EXPOSE_METRICS` environment variable is set to `true`. The port can be specified using the `CONNECTOR_METRICS_PORT` variable. Those metrics can be accessible from any connector using the `helper`.
Metrics created: 

Metric | Type | Description
-- | -- | --
bundle_send | Counter | The number of bundle that have been sent using the "send_bundle" function from pycti
record_send | Counter | The number of record (objects per bundle) send by the connector
run_count | Counter | The number of time the connector has run
error_count | Counter | The number of error that occurs in the connector
client_error_count | Counter | The number of error that occurs in the client when communicating with the remote data source
state | Enum | The state in which the connector is. One of `idle`, `running`, `stopped`

Some metrics, like the number of bundle send, can be computed directly in the client whereas some metrics need to be implemented on the connector side.

### Related issues

- #213 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so. 
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
