### PR TITLE
Moving "cyber observable" creation before creation of "observed data"…

### DIFF
--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -536,18 +536,20 @@ class ObservedData:
         if "objects" in stix_object:
             stix_observable_results = []
             for key, observable_item in stix_object["objects"].items():
-                stix_observable_results.append(self.opencti.stix_cyber_observable.create(
-                    observableData=observable_item,
-                    createdBy=extras["created_by_id"]
-                    if "created_by_id" in extras
-                    else None,
-                    objectMarking=extras["object_marking_ids"]
-                    if "object_marking_ids" in extras
-                    else None,
-                    objectLabel=extras["object_label_ids"]
-                    if "object_label_ids" in extras
-                    else [],
-                ))
+                stix_observable_results.append(
+                    self.opencti.stix_cyber_observable.create(
+                        observableData=observable_item,
+                        createdBy=extras["created_by_id"]
+                        if "created_by_id" in extras
+                        else None,
+                        objectMarking=extras["object_marking_ids"]
+                        if "object_marking_ids" in extras
+                        else None,
+                        objectLabel=extras["object_label_ids"]
+                        if "object_label_ids" in extras
+                        else [],
+                    )
+                )
                 refs = []
                 for item in stix_observable_results:
                     refs.append(item["standard_id"])

--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -532,6 +532,27 @@ class ObservedData:
         stix_object = kwargs.get("stixObject", None)
         extras = kwargs.get("extras", {})
         update = kwargs.get("update", False)
+
+        if "objects" in stix_object:
+            stix_observable_results = []
+            for key, observable_item in stix_object["objects"].items():
+                stix_observable_results.append(self.opencti.stix_cyber_observable.create(
+                    observableData=observable_item,
+                    createdBy=extras["created_by_id"]
+                    if "created_by_id" in extras
+                    else None,
+                    objectMarking=extras["object_marking_ids"]
+                    if "object_marking_ids" in extras
+                    else None,
+                    objectLabel=extras["object_label_ids"]
+                    if "object_label_ids" in extras
+                    else [],
+                ))
+                refs = []
+                for item in stix_observable_results:
+                    refs.append(item["standard_id"])
+                stix_object["object_refs"] = refs
+
         if stix_object is not None:
             observed_data_result = self.create(
                 stix_id=stix_object["id"],
@@ -571,31 +592,7 @@ class ObservedData:
                 else None,
                 update=update,
             )
-            if "objects" in stix_object:
-                for key, observable_item in stix_object["objects"].items():
-                    stix_observable_result = self.opencti.stix_cyber_observable.create(
-                        observableData=observable_item,
-                        createdBy=extras["created_by_id"]
-                        if "created_by_id" in extras
-                        else None,
-                        objectMarking=extras["object_marking_ids"]
-                        if "object_marking_ids" in extras
-                        else None,
-                        objectLabel=extras["object_label_ids"]
-                        if "object_label_ids" in extras
-                        else [],
-                    )
-                    if stix_observable_result is not None:
-                        self.add_stix_object_or_stix_relationship(
-                            id=observed_data_result["id"],
-                            stixObjectOrStixRelationshipId=stix_observable_result["id"],
-                        )
-                        self.opencti.stix2.mapping_cache[
-                            stix_observable_result["id"]
-                        ] = {
-                            "id": stix_observable_result["id"],
-                            "type": stix_observable_result["entity_type"],
-                        }
+
             return observed_data_result
         else:
             self.opencti.log(


### PR DESCRIPTION
… object to fix a bug in stix2.0 format.

### Proposed changes

* Move cyber observable object creation (self.opencti.stix_cyber_observable.create) before creation of observed data in self.create.
* Format STIX2.0 "objects" to 2.1 "object_refs" format before self.create and after creation of observables.
* Remove creation of relationship object (not needed when formatted to stix2.1 supported object refs and self.create() used)

### Related issues

* Unable to ingest STIX2.0 formatted bundle with observed data structure. Example error:

`ERROR:root:Traceback (most recent call last):
  File "\opencti\opencti-worker\src\worker.py", line 167, in data_handler
    self.api.stix2.import_bundle_from_json(
  File "\AppData\Local\Programs\Python\Python39\lib\site-packages\pycti\utils\opencti_stix2.py", line 200, in import_bundle_from_json
    return self.import_bundle(
  File "\AppData\Local\Programs\Python\Python39\lib\site-packages\pycti\utils\opencti_stix2.py", line 1645, in import_bundle
    self.import_object(item, update, types)
  File "\AppData\Local\Programs\Python\Python39\lib\site-packages\pycti\utils\opencti_stix2.py", line 558, in import_object
    stix_object_results = do_import(
  File "\AppData\Local\Programs\Python\Python39\lib\site-packages\pycti\entities\opencti_observed_data.py", line 590, in import_from_stix2
    id=observed_data_result["id"],
TypeError: 'NoneType' object is not subscriptable`

In the above error, observed_data_result["id"] is None due to unable to satisfy required arguments in line 566 arguments to self.create()
objects=stix_object["object_refs"]

hence self.create() returns None.

In the existing implementation, the "objects" list (supported by stix2.0) is checked only after the above observed_data_result is attempted to be created. Parsing of "objects" of stix_object is required in order to create observed_data_result.


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

I have not created or adjusted the test cases.

Example input to trigger the error was given via ImportFileStix connector:
`
{
    "objects": [
        {
            "first_observed": "2021-11-09T15:44:22.65Z",
            "last_observed": "2021-11-09T15:44:23.65Z",
            "number_observed": 1,
            "objects": {
                "0": {
                    "hashes": {
                        "MD5": "ad7b9c14083b52bc532fba5948342b98",
                        "SHA-1": "ee8cbf12d87c4d388f09b4f69bed2e91682920b5",
                        "SHA-256": "17f746d82695fa9b35493b41859d39d786d32b23a9d2e00f4011dec7a02402ae"
                    },
                    "name": "C:\\Users\\<USER>\\AppData\\Local\\libcqppj\\cmd.exe",
                    "size": 302592,
                    "mime_type": "application/octet-stream",
                    "type": "file"
                }
            },
            "type": "observed-data",
            "id": "observed-data--2a4ef65d-3ec8-4d52-b104-e7ca228246f9",
            "created": "2021-11-09T15:44:22.659Z",
            "modified": "2021-11-09T15:44:22.659Z"
        }
    ],
    "type": "bundle",
    "id": "bundle--a2b9a267-b457-424d-8696-834607976438",
    "spec_version": "2.0"
}
`