### PR TITLE
Adding iteration of pages when all malware is requested with getAll

### DIFF
--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -203,9 +203,32 @@ class Malware:
                 "orderMode": order_mode,
             },
         )
-        return self.opencti.process_multiple(
-            result["data"]["malwares"], with_pagination
-        )
+
+        if get_all:
+            final_data = []
+            data = self.opencti.process_multiple(result["data"]["malwares"])
+            final_data = final_data + data
+            while result["data"]["malwares"]["pageInfo"]["hasNextPage"]:
+                after = result["data"]["malwares"]["pageInfo"]["endCursor"]
+                self.opencti.log("info", "Listing Malwares after " + after)
+                result = self.opencti.query(
+                    query,
+                    {
+                        "filters": filters,
+                        "search": search,
+                        "first": first,
+                        "after": after,
+                        "orderBy": order_by,
+                        "orderMode": order_mode,
+                    },
+                )
+                data = self.opencti.process_multiple(result["data"]["malwares"])
+                final_data = final_data + data
+            return final_data
+        else:
+            return self.opencti.process_multiple(
+                result["data"]["malwares"], with_pagination
+            )
 
     """
         Read a Malware object


### PR DESCRIPTION

### Proposed changes

* Adding iteration of pages from GraphQL response to malware entity api

### Related issues

* getAll argument for malware.list() only returns first 500

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality