### PR TITLE
[stix_cyber_observable] Fix KeyError in parsing Email-Message Observable

### DIFF
--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -748,7 +748,7 @@ class StixCyberObservable:
                     "is_multipart": observable_data["is_multipart"]
                     if "is_multipart" in observable_data
                     else None,
-                    "attribute_date": observable_data["attribute_date"]
+                    "attribute_date": observable_data["date"]
                     if "date" in observable_data
                     else None,
                     "message_id": observable_data["message_id"]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix KeyError occurs when creating the observable of the Email-Message with the date field from an STIX Bundle Object which includes it.

### Related issues

* No

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
