### PR TITLE
[client/api] Include rabbitmq vhost field in query (opencti-#2199)

### DIFF
--- a/pycti/api/opencti_api_connector.py
+++ b/pycti/api/opencti_api_connector.py
@@ -27,6 +27,7 @@ class OpenCTIApiConnector:
                     config {
                         connection {
                             host
+                            vhost
                             use_ssl
                             port
                             user
@@ -82,6 +83,7 @@ class OpenCTIApiConnector:
                     config {
                         connection {
                             host
+                            vhost
                             use_ssl
                             port
                             user

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -116,6 +116,7 @@ class ListenQueue(threading.Thread):
         self.helper = helper
         self.callback = callback
         self.host = config["connection"]["host"]
+        self.vhost = config["connection"]["vhost"]
         self.use_ssl = config["connection"]["use_ssl"]
         self.port = config["connection"]["port"]
         self.user = config["connection"]["user"]
@@ -192,7 +193,7 @@ class ListenQueue(threading.Thread):
                 self.pika_parameters = pika.ConnectionParameters(
                     host=self.host,
                     port=self.port,
-                    virtual_host="/",
+                    virtual_host=self.vhost,
                     credentials=self.pika_credentials,
                     ssl_options=pika.SSLOptions(create_ssl_context(), self.host)
                     if self.use_ssl
@@ -789,7 +790,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         pika_parameters = pika.ConnectionParameters(
             host=self.config["connection"]["host"],
             port=self.config["connection"]["port"],
-            virtual_host="/",
+            virtual_host=self.config["connection"]["vhost"],
             credentials=pika_credentials,
             ssl_options=pika.SSLOptions(
                 create_ssl_context(), self.config["connection"]["host"]


### PR DESCRIPTION
### Proposed changes

* Include `vhost` as a field returned from the graphql connector config query.

### Related issues

* Add RabbitMQ vhost configuration option
* In support of OpenCTI-Platform/opencti/issues/2199

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] ~~I wrote test cases for the relevant uses case~~
- [x] ~~I added/update the relevant documentation (either on github or on notion)~~
- [x] ~~Where necessary I refactored code to improve the overall quality~~

### Further comments

- 👍 
