### PR TITLE
Fix param order in logging call

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -83,7 +83,7 @@ class OpenCTIStix2:
             date_value = datetime.datetime.utcnow()
 
         if not date_value.tzinfo:
-            self.opencti.log("No timezone found. Setting to UTC", "info")
+            self.opencti.log("info", "No timezone found. Setting to UTC")
             date_value = date_value.replace(tzinfo=datetime.timezone.utc)
 
         return date_value.isoformat(timespec="milliseconds").replace("+00:00", "Z")


### PR DESCRIPTION
### Proposed changes

* Method signature is [`OpenCTIApiClient().log(level: str, message: str) -> None`][1].
* Invalid call is doing `log(message, level)`:
  ```py
  self.opencti.log("No timezone found. Setting to UTC", "info")
  ```
* Change is fixing the order of parameters when calling the method.

[1]: https://github.com/OpenCTI-Platform/client-python/blob/27bf0965e405a256878b191c75030b9c22e9fcb7/pycti/api/opencti_api_client.py#L357

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
