### PR TITLE
Improve logging

### DIFF
--- a/pycti/api/__init__.py
+++ b/pycti/api/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)

--- a/pycti/api/opencti_api_connector.py
+++ b/pycti/api/opencti_api_connector.py
@@ -1,7 +1,7 @@
 import json
-import logging
 from typing import Any, Dict
 
+from pycti.api import LOGGER
 from pycti.connector.opencti_connector import OpenCTIConnector
 
 
@@ -18,7 +18,7 @@ class OpenCTIApiConnector:
         :rtype: dict
         """
 
-        logging.info("Getting connectors ...")
+        LOGGER.info("Getting connectors ...")
         query = """
             query GetConnectors {
                 connectorsForWorker {

--- a/pycti/api/opencti_api_work.py
+++ b/pycti/api/opencti_api_work.py
@@ -1,6 +1,7 @@
-import logging
 import time
 from typing import Dict, List
+
+from pycti.api import LOGGER
 
 
 class OpenCTIApiWork:
@@ -10,7 +11,7 @@ class OpenCTIApiWork:
         self.api = api
 
     def to_received(self, work_id: str, message: str):
-        logging.info("Reporting work update_received " + work_id)
+        LOGGER.info("Reporting work update_received %s", work_id)
         query = """
             mutation workToReceived($id: ID!, $message: String) {
                 workEdit(id: $id) {
@@ -21,7 +22,7 @@ class OpenCTIApiWork:
         self.api.query(query, {"id": work_id, "message": message})
 
     def to_processed(self, work_id: str, message: str, in_error: bool = False):
-        logging.info("Reporting work update_received " + work_id)
+        LOGGER.info("Reporting work update_received %s", work_id)
         query = """
             mutation workToProcessed($id: ID!, $message: String, $inError: Boolean) {
                 workEdit(id: $id) {
@@ -32,7 +33,7 @@ class OpenCTIApiWork:
         self.api.query(query, {"id": work_id, "message": message, "inError": in_error})
 
     def ping(self, work_id: str):
-        logging.info("Ping work " + work_id)
+        LOGGER.info("Ping work %s", work_id)
         query = """
             mutation pingWork($id: ID!) {
                 workEdit(id: $id) {
@@ -43,7 +44,7 @@ class OpenCTIApiWork:
         self.api.query(query, {"id": work_id})
 
     def report_expectation(self, work_id: str, error):
-        logging.info("Report expectation for " + work_id)
+        LOGGER.info("Report expectation for %s", work_id)
         query = """
             mutation reportExpectation($id: ID!, $error: WorkErrorInput) {
                 workEdit(id: $id) {
@@ -57,9 +58,7 @@ class OpenCTIApiWork:
             self.api.log("error", "Cannot report expectation")
 
     def add_expectations(self, work_id: str, expectations: int):
-        logging.info(
-            "Update action expectations " + work_id + " - " + str(expectations)
-        )
+        LOGGER.info("Update action expectations %s - %s", work_id, expectations)
         query = """
             mutation addExpectations($id: ID!, $expectations: Int) {
                 workEdit(id: $id) {
@@ -73,7 +72,7 @@ class OpenCTIApiWork:
             self.api.log("error", "Cannot report expectation")
 
     def initiate_work(self, connector_id: str, friendly_name: str) -> str:
-        logging.info("Initiate work for " + connector_id)
+        LOGGER.info("Initiate work for %s", connector_id)
         query = """
             mutation workAdd($connectorId: String!, $friendlyName: String) {
                 workAdd(connectorId: $connectorId, friendlyName: $friendlyName) {

--- a/pycti/connector/__init__.py
+++ b/pycti/connector/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -19,6 +19,7 @@ from pika.exceptions import NackError, UnroutableError
 from sseclient import SSEClient
 
 from pycti.api.opencti_api_client import OpenCTIApiClient
+from pycti.connector import LOGGER
 from pycti.connector.opencti_connector import OpenCTIConnector
 from pycti.utils.opencti_stix2_splitter import OpenCTIStix2Splitter
 
@@ -45,7 +46,7 @@ def get_config_variable(
 ) -> Union[bool, int, None, str]:
     """[summary]
 
-    :param env_var: environnement variable name
+    :param env_var: environment variable name
     :param yaml_path: path to yaml config
     :param config: client config dict, defaults to {}
     :param isNumber: specify if the variable is a number, defaults to False
@@ -157,12 +158,9 @@ class ListenQueue(threading.Thread):
                 time_wait += 1
             time.sleep(1)
 
-        logging.info(
-            "%s",
-            (
-                f"Message (delivery_tag={method.delivery_tag}) processed"
-                ", thread terminated"
-            ),
+        LOGGER.info(
+            "Message (delivery_tag=%s) processed, thread terminated",
+            method.delivery_tag,
         )
 
     def _data_handler(self, json_data) -> None:
@@ -181,11 +179,11 @@ class ListenQueue(threading.Thread):
             message = self.callback(json_data["event"])
             self.helper.api.work.to_processed(work_id, message)
         except Exception as e:  # pylint: disable=broad-except
-            logging.exception("Error in message processing, reporting error to API")
+            LOGGER.exception("Error in message processing, reporting error to API")
             try:
                 self.helper.api.work.to_processed(work_id, str(e), True)
             except:  # pylint: disable=bare-except
-                logging.error("Failing reporting the processing")
+                LOGGER.error("Failing reporting the processing")
 
     def run(self) -> None:
         while not self.exit_event.is_set():
@@ -209,10 +207,10 @@ class ListenQueue(threading.Thread):
                 )
                 self.channel.start_consuming()
             except (KeyboardInterrupt, SystemExit):
-                self.helper.log_info("Connector stop")
+                LOGGER.info("Connector stop")
                 sys.exit(0)
             except Exception as e:  # pylint: disable=broad-except
-                self.helper.log_error(str(e))
+                LOGGER.error("%s", e)
                 time.sleep(10)
 
     def stop(self):
@@ -244,27 +242,24 @@ class PingAlive(threading.Thread):
                 )
                 if initial_state != remote_state:
                     self.set_state(result["connector_state"])
-                    logging.info(
-                        "%s",
-                        (
-                            "Connector state has been remotely reset to: "
-                            f'"{self.get_state()}"'
-                        ),
+                    LOGGER.info(
+                        'Connector state has been remotely reset to: "%s"',
+                        self.get_state(),
                     )
                 if self.in_error:
                     self.in_error = False
-                    logging.error("API Ping back to normal")
+                    LOGGER.error("API Ping back to normal")
             except Exception:  # pylint: disable=broad-except
                 self.in_error = True
-                logging.error("Error pinging the API")
+                LOGGER.error("Error pinging the API")
             self.exit_event.wait(40)
 
     def run(self) -> None:
-        logging.info("Starting ping alive thread")
+        LOGGER.info("Starting ping alive thread")
         self.ping()
 
     def stop(self) -> None:
-        logging.info("Preparing for clean shutdown")
+        LOGGER.info("Preparing for clean shutdown")
         self.exit_event.set()
 
 
@@ -276,7 +271,7 @@ class StreamAlive(threading.Thread):
 
     def run(self) -> None:
         try:
-            logging.info("Starting stream alive thread")
+            LOGGER.info("Starting stream alive thread")
             time_since_last_heartbeat = 0
             while not self.exit_event.is_set():
                 time.sleep(5)
@@ -286,7 +281,7 @@ class StreamAlive(threading.Thread):
                 except queue.Empty:
                     time_since_last_heartbeat = time_since_last_heartbeat + 5
                     if time_since_last_heartbeat > 45:
-                        logging.error(
+                        LOGGER.error(
                             "Time since last heartbeat exceeded 45s, stopping the connector"
                         )
                         break
@@ -295,7 +290,7 @@ class StreamAlive(threading.Thread):
             sys.excepthook(*sys.exc_info())
 
     def stop(self) -> None:
-        logging.info("Preparing for clean shutdown")
+        LOGGER.info("Preparing for clean shutdown")
         self.exit_event.set()
 
 
@@ -380,16 +375,10 @@ class ListenStream(threading.Thread):
             listen_delete = str(self.listen_delete).lower()
             no_dependencies = str(self.no_dependencies).lower()
             with_inferences = str(self.with_inferences).lower()
-            logging.info(
-                'Starting to listen stream events on "'
-                + live_stream_url
-                + '" (listen-delete: '
-                + listen_delete
-                + ", no-dependencies: "
-                + no_dependencies
-                + ", with-inferences: "
-                + with_inferences
-                + ")"
+            LOGGER.info(
+                'Starting to listen stream events on "%s" '
+                "(listen-delete: %s, no-dependencies: %s, with-inferences: %s)",
+                *(live_stream_url, listen_delete, no_dependencies, with_inferences),
             )
             messages = SSEClient(
                 live_stream_url,
@@ -527,8 +516,8 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             False,
         )
         self.log_level = get_config_variable(
-            "CONNECTOR_LOG_LEVEL", ["connector", "log_level"], config
-        )
+            "CONNECTOR_LOG_LEVEL", ["connector", "log_level"], config, default="INFO"
+        ).upper()
         self.connect_run_and_terminate = get_config_variable(
             "CONNECTOR_RUN_AND_TERMINATE",
             ["connector", "run_and_terminate"],
@@ -545,12 +534,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         )
 
         # Configure logger
-        numeric_level = getattr(
-            logging, self.log_level.upper() if self.log_level else "INFO", None
-        )
-        if not isinstance(numeric_level, int):
-            raise ValueError(f"Invalid log level: {self.log_level}")
-        logging.basicConfig(level=numeric_level)
+        logging.basicConfig(level=self.log_level)
 
         # Initialize configuration
         # - Classic API that will be directly attached to the connector rights
@@ -579,7 +563,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.connect_only_contextual,
         )
         connector_configuration = self.api.connector.register(self.connector)
-        logging.info("%s", f"Connector registered with ID: {self.connect_id}")
+        LOGGER.info("Connector registered with ID: %s", self.connect_id)
         self.connector_id = connector_configuration["id"]
         self.work_id = None
         self.applicant_id = connector_configuration["connector_user_id"]
@@ -656,7 +640,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             if initial_state != remote_state:
                 self.api.connector.ping(self.connector_id, initial_state)
         except Exception:  # pylint: disable=broad-except
-            logging.error("Error pinging the API")
+            LOGGER.error("Error pinging the API")
 
     def listen(self, message_callback: Callable[[Dict], str]) -> None:
         """listen for messages and register callback function
@@ -760,18 +744,6 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
 
     def get_connector(self) -> OpenCTIConnector:
         return self.connector
-
-    def log_error(self, msg: str) -> None:
-        logging.error(msg)
-
-    def log_info(self, msg: str) -> None:
-        logging.info(msg)
-
-    def log_debug(self, msg: str) -> None:
-        logging.debug(msg)
-
-    def log_warning(self, msg: str) -> None:
-        logging.warning(msg)
 
     def date_now(self) -> str:
         """get the current date (UTC)
@@ -927,7 +899,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                 ),
             )
         except (UnroutableError, NackError) as e:
-            logging.error("Unable to send bundle, retry...%s", e)
+            LOGGER.error("Unable to send bundle, retry...%s", e)
             self._send_bundle(channel, bundle, **kwargs)
 
     def stix2_get_embedded_objects(self, item) -> Dict:

--- a/pycti/entities/__init__.py
+++ b/pycti/entities/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)

--- a/pycti/entities/opencti_attack_pattern.py
+++ b/pycti/entities/opencti_attack_pattern.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class AttackPattern:
@@ -178,9 +181,8 @@ class AttackPattern:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Attack-Patterns with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Attack-Patterns with filters %s.", json.dumps(filters))
         query = (
             """
             query AttackPatterns($filters: [AttackPatternsFiltering], $search: String, $first: Int, $after: ID, $orderBy: AttackPatternsOrdering, $orderMode: OrderingMode) {
@@ -220,7 +222,7 @@ class AttackPattern:
             final_data = final_data + data
             while result["data"]["attackPatterns"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["attackPatterns"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Attack-Patterns after " + after)
+                LOGGER.info("Listing Attack-Patterns after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -253,7 +255,7 @@ class AttackPattern:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Attack-Pattern {" + id + "}.")
+            LOGGER.info("Reading Attack-Pattern {%s}.", id)
             query = (
                 """
                 query AttackPattern($id: String!) {
@@ -278,9 +280,7 @@ class AttackPattern:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: id or filters")
             return None
 
     """
@@ -314,7 +314,7 @@ class AttackPattern:
         update = kwargs.get("update", False)
 
         if name is not None:
-            self.opencti.log("info", "Creating Attack-Pattern {" + name + "}.")
+            LOGGER.info("Creating Attack-Pattern {%s}.", name)
             query = """
                 mutation AttackPatternAdd($input: AttackPatternAddInput) {
                     attackPatternAdd(input: $input) {
@@ -357,9 +357,8 @@ class AttackPattern:
                 result["data"]["attackPatternAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_attack_pattern] Missing parameters: name and description",
+            LOGGER.error(
+                "[opencti_attack_pattern] Missing parameters: name and description"
             )
 
     """
@@ -487,14 +486,12 @@ class AttackPattern:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")
 
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Attack Pattern {" + id + "}.")
+            LOGGER.info("Deleting Attack Pattern {%s}.", id)
             query = """
                  mutation AttackPatternEdit($id: ID!) {
                      attackPatternEdit(id: $id) {
@@ -504,5 +501,5 @@ class AttackPattern:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log("error", "[attack_pattern] Missing parameters: id")
+            LOGGER.error("[attack_pattern] Missing parameters: id")
             return None

--- a/pycti/entities/opencti_campaign.py
+++ b/pycti/entities/opencti_campaign.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Campaign:
@@ -160,9 +163,8 @@ class Campaign:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Campaigns with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Campaigns with filters %s.", json.dumps(filters))
         query = (
             """
             query Campaigns($filters: [CampaignsFiltering], $search: String, $first: Int, $after: ID, $orderBy: CampaignsOrdering, $orderMode: OrderingMode) {
@@ -213,7 +215,7 @@ class Campaign:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Campaign {" + id + "}.")
+            LOGGER.info("Reading Campaign {%s}.", id)
             query = (
                 """
                 query Campaign($id: String!) {
@@ -238,9 +240,7 @@ class Campaign:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_campaign] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_campaign] Missing parameters: id or filters")
             return None
 
     """
@@ -272,7 +272,7 @@ class Campaign:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Campaign {" + name + "}.")
+            LOGGER.info("Creating Campaign {%s}.", name)
             query = """
                 mutation CampaignAdd($input: CampaignAddInput) {
                     campaignAdd(input: $input) {
@@ -311,9 +311,7 @@ class Campaign:
             )
             return self.opencti.process_multiple_fields(result["data"]["campaignAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_campaign] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_campaign] Missing parameters: name and description")
 
     """
         Import a Campaign object from a STIX2 object
@@ -384,6 +382,4 @@ class Campaign:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_campaign] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_campaign] Missing parameters: stixObject")

--- a/pycti/entities/opencti_channel.py
+++ b/pycti/entities/opencti_channel.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Channel:
@@ -158,9 +161,8 @@ class Channel:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Channels with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Channels with filters %s.", json.dumps(filters))
         query = (
             """
             query Channels($filters: [ChannelsFiltering!], $search: String, $first: Int, $after: ID, $orderBy: ChannelsOrdering, $orderMode: OrderingMode) {
@@ -200,7 +202,7 @@ class Channel:
             final_data = final_data + data
             while result["data"]["channels"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["channels"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Channels after " + after)
+                LOGGER.info("Listing Channels after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -233,7 +235,7 @@ class Channel:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Channel {" + id + "}.")
+            LOGGER.info("Reading Channel {%s}.", id)
             query = (
                 """
                 query Channel($id: String!) {
@@ -258,9 +260,7 @@ class Channel:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_channel] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_channel] Missing parameters: id or filters")
             return None
 
     """
@@ -290,7 +290,7 @@ class Channel:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Channel {" + name + "}.")
+            LOGGER.info("Creating Channel {%s}.", name)
             query = """
                 mutation ChannelAdd($input: ChannelAddInput!) {
                     channelAdd(input: $input) {
@@ -327,9 +327,7 @@ class Channel:
             )
             return self.opencti.process_multiple_fields(result["data"]["channelAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_channel] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_channel] Missing parameters: name and description")
 
     """
         Import an Channel object from a STIX2 object
@@ -394,6 +392,4 @@ class Channel:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_channel] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_channel] Missing parameters: stixObject")

--- a/pycti/entities/opencti_course_of_action.py
+++ b/pycti/entities/opencti_course_of_action.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class CourseOfAction:
@@ -161,10 +164,10 @@ class CourseOfAction:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info",
-            "Listing Course-Of-Actions with filters " + json.dumps(filters) + ".",
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info(
+                "Listing Course-Of-Actions with filters %s.", json.dumps(filters)
+            )
         query = (
             """
             query CoursesOfAction($filters: [CoursesOfActionFiltering], $search: String, $first: Int, $after: ID, $orderBy: CoursesOfActionOrdering, $orderMode: OrderingMode) {
@@ -215,7 +218,7 @@ class CourseOfAction:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Course-Of-Action {" + id + "}.")
+            LOGGER.info("Reading Course-Of-Action {%s}.", id)
             query = (
                 """
                 query CourseOfAction($id: String!) {
@@ -242,9 +245,7 @@ class CourseOfAction:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_course_of_action] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_course_of_action] Missing parameters: id or filters")
             return None
 
     """
@@ -274,7 +275,7 @@ class CourseOfAction:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Course Of Action {" + name + "}.")
+            LOGGER.info("Creating Course Of Action {%s}.", name)
             query = """
                 mutation CourseOfActionAdd($input: CourseOfActionAddInput) {
                     courseOfActionAdd(input: $input) {
@@ -313,9 +314,8 @@ class CourseOfAction:
                 result["data"]["courseOfActionAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_course_of_action] Missing parameters: name and description",
+            LOGGER.error(
+                "[opencti_course_of_action] Missing parameters: name and description"
             )
 
     """
@@ -403,6 +403,4 @@ class CourseOfAction:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_course_of_action] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_course_of_action] Missing parameters: stixObject")

--- a/pycti/entities/opencti_event.py
+++ b/pycti/entities/opencti_event.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Event:
@@ -160,9 +163,8 @@ class Event:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Events with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Events with filters %s", json.dumps(filters))
         query = (
             """
             query Events($filters: [EventsFiltering!], $search: String, $first: Int, $after: ID, $orderBy: EventsOrdering, $orderMode: OrderingMode) {
@@ -202,7 +204,7 @@ class Event:
             final_data = final_data + data
             while result["data"]["events"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["events"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Events after " + after)
+                LOGGER.info("Listing Events after %s", after)
                 result = self.opencti.query(
                     query,
                     {
@@ -235,7 +237,7 @@ class Event:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Event {" + id + "}.")
+            LOGGER.info("Reading Event {%s}.", id)
             query = (
                 """
                 query Event($id: String!) {
@@ -260,9 +262,7 @@ class Event:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_event] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_event] Missing parameters: id or filters")
             return None
 
     """
@@ -294,7 +294,7 @@ class Event:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Event {" + name + "}.")
+            LOGGER.info("Creating Event {%s}.", name)
             query = """
                 mutation EventAdd($input: EventAddInput!) {
                     eventAdd(input: $input) {
@@ -333,9 +333,7 @@ class Event:
             )
             return self.opencti.process_multiple_fields(result["data"]["eventAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_event] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_event] Missing parameters: name and description")
 
     """
         Import an Event object from a STIX2 object
@@ -406,4 +404,4 @@ class Event:
                 update=update,
             )
         else:
-            self.opencti.log("error", "[opencti_event] Missing parameters: stixObject")
+            LOGGER.error("[opencti_event] Missing parameters: stixObject")

--- a/pycti/entities/opencti_external_reference.py
+++ b/pycti/entities/opencti_external_reference.py
@@ -1,11 +1,14 @@
 # coding: utf-8
 
 import json
+import logging
 import os
 import uuid
 
 import magic
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class ExternalReference:
@@ -74,10 +77,10 @@ class ExternalReference:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info",
-            "Listing External-Reference with filters " + json.dumps(filters) + ".",
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info(
+                "Listing External-Reference with filters %s.", json.dumps(filters)
+            )
         query = (
             """
             query ExternalReferences($filters: [ExternalReferencesFiltering], $first: Int, $after: ID, $orderBy: ExternalReferencesOrdering, $orderMode: OrderingMode) {
@@ -126,7 +129,7 @@ class ExternalReference:
         id = kwargs.get("id", None)
         filters = kwargs.get("filters", None)
         if id is not None:
-            self.opencti.log("info", "Reading External-Reference {" + id + "}.")
+            LOGGER.info("Reading External-Reference {%s}.", id)
             query = (
                 """
                 query ExternalReference($id: String!) {
@@ -149,9 +152,8 @@ class ExternalReference:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_external_reference] Missing parameters: id or filters",
+            LOGGER.error(
+                "[opencti_external_reference] Missing parameters: id or filters"
             )
             return None
 
@@ -174,9 +176,7 @@ class ExternalReference:
         update = kwargs.get("update", False)
 
         if source_name is not None or url is not None:
-            self.opencti.log(
-                "info", "Creating External Reference {" + source_name + "}."
-            )
+            LOGGER.info("Creating External Reference {%s}.", source_name)
             query = (
                 """
                 mutation ExternalReferenceAdd($input: ExternalReferenceAddInput) {
@@ -208,9 +208,8 @@ class ExternalReference:
                 result["data"]["externalReferenceAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_external_reference] Missing parameters: source_name and url",
+            LOGGER.error(
+                "[opencti_external_reference] Missing parameters: source_name and url"
             )
 
     """
@@ -245,22 +244,16 @@ class ExternalReference:
                     mime_type = "application/json"
                 else:
                     mime_type = magic.from_file(file_name, mime=True)
-            self.opencti.log(
-                "info",
-                "Uploading a file {"
-                + final_file_name
-                + "} in Stix-Domain-Object {"
-                + id
-                + "}.",
+            LOGGER.info(
+                "Uploading a file {%s} in Stix-Domain-Object {%s}.", final_file_name, id
             )
             return self.opencti.query(
                 query,
                 {"id": id, "file": (self.file(final_file_name, data, mime_type))},
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_stix_domain_object] Missing parameters: id or file_name",
+            LOGGER.error(
+                "[opencti_stix_domain_object] Missing parameters: id or file_name"
             )
             return None
 
@@ -276,7 +269,7 @@ class ExternalReference:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating External-Reference {" + id + "}.")
+            LOGGER.info("Updating External-Reference {%s}.", id)
             query = """
                     mutation ExternalReferenceEdit($id: ID!, $input: [EditInput]!) {
                         externalReferenceEdit(id: $id) {
@@ -291,14 +284,13 @@ class ExternalReference:
                 result["data"]["externalReferenceEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_external_reference] Missing parameters: id and key and value",
+            LOGGER.error(
+                "[opencti_external_reference] Missing parameters: id and key and value"
             )
             return None
 
     def delete(self, id):
-        self.opencti.log("info", "Deleting External-Reference " + id + "...")
+        LOGGER.info("Deleting External-Reference " + id + "...")
         query = """
              mutation ExternalReferenceEdit($id: ID!) {
                  externalReferenceEdit(id: $id) {
@@ -310,10 +302,7 @@ class ExternalReference:
 
     def list_files(self, **kwargs):
         id = kwargs.get("id", None)
-        self.opencti.log(
-            "info",
-            "Listing files of External-Reference { " + id + " }",
-        )
+        LOGGER.info("Listing files of External-Reference { " + id + " }")
         query = """
             query externalReference($id: String!) {
                 externalReference(id: $id) {

--- a/pycti/entities/opencti_grouping.py
+++ b/pycti/entities/opencti_grouping.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Grouping:
@@ -251,9 +254,8 @@ class Grouping:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Groupings with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Groupings with filters %s.", json.dumps(filters))
         query = (
             """
             query Groupings($filters: [GroupingsFiltering!], $search: String, $first: Int, $after: ID, $orderBy: GroupingsOrdering, $orderMode: OrderingMode) {
@@ -293,7 +295,7 @@ class Grouping:
             final_data = final_data + data
             while result["data"]["groupings"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["groupings"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Groupings after " + after)
+                LOGGER.info("Listing Groupings after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -326,7 +328,7 @@ class Grouping:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Grouping {" + id + "}.")
+            LOGGER.info("Reading Grouping {%s}.", id)
             query = (
                 """
                 query Grouping($id: String!) {
@@ -392,13 +394,9 @@ class Grouping:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Checking StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} in Grouping {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Checking StixObjectOrStixRelationship {%s} in Grouping {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                 query GroupingContainsStixObjectOrStixRelationship($id: String!, $stixObjectOrStixRelationshipId: String!) {
@@ -414,9 +412,8 @@ class Grouping:
             )
             return result["data"]["groupingContainsStixObjectOrStixRelationship"]
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_grouping] Missing parameters: id or stixObjectOrStixRelationshipId",
+            LOGGER.error(
+                "[opencti_grouping] Missing parameters: id or stixObjectOrStixRelationshipId"
             )
 
     """
@@ -447,7 +444,7 @@ class Grouping:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None and context is not None:
-            self.opencti.log("info", "Creating Grouping {" + name + "}.")
+            LOGGER.info("Creating Grouping {%s}.", name)
             query = """
                 mutation GroupingAdd($input: GroupingAddInput!) {
                     groupingAdd(input: $input) {
@@ -485,9 +482,8 @@ class Grouping:
             )
             return self.opencti.process_multiple_fields(result["data"]["groupingAdd"])
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_grouping] Missing parameters: name and description and context",
+            LOGGER.error(
+                "[opencti_grouping] Missing parameters: name and description and context"
             )
 
     """
@@ -504,13 +500,9 @@ class Grouping:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Adding StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to Grouping {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Adding StixObjectOrStixRelationship {%s} to Grouping {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                mutation GroupingEditRelationAdd($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -531,8 +523,7 @@ class Grouping:
             )
             return True
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_grouping] Missing parameters: id and stixObjectOrStixRelationshipId",
             )
             return False
@@ -551,13 +542,9 @@ class Grouping:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to Grouping {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing StixObjectOrStixRelationship {%s} to {%s}",
+                *(stix_object_or_stix_relationship_id, Grouping),
             )
             query = """
                mutation GroupingEditRelationDelete($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -576,8 +563,7 @@ class Grouping:
             )
             return True
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_grouping] Missing parameters: id and stixObjectOrStixRelationshipId",
             )
             return False
@@ -648,6 +634,4 @@ class Grouping:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_grouping] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_grouping] Missing parameters: stixObject")

--- a/pycti/entities/opencti_identity.py
+++ b/pycti/entities/opencti_identity.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
 
+from pycti.entities import LOGGER
 from pycti.utils.constants import IdentityTypes
 
 
@@ -171,9 +173,8 @@ class Identity:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Identities with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Identities with filters %s.", json.dumps(filters))
         query = (
             """
             query Identities($types: [String], $filters: [IdentitiesFiltering], $search: String, $first: Int, $after: ID, $orderBy: IdentitiesOrdering, $orderMode: OrderingMode) {
@@ -225,7 +226,7 @@ class Identity:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Identity {" + id + "}.")
+            LOGGER.info("Reading Identity {%s}.", id)
             query = (
                 """
                 query Identity($id: String!) {
@@ -250,9 +251,7 @@ class Identity:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_identity] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_identity] Missing parameters: id or filters")
             return None
 
     """
@@ -287,7 +286,7 @@ class Identity:
         update = kwargs.get("update", False)
 
         if type is not None and name is not None and description is not None:
-            self.opencti.log("info", "Creating Identity {" + name + "}.")
+            LOGGER.info("Creating Identity {%s}.", name)
             input_variables = {
                 "stix_id": stix_id,
                 "createdBy": created_by,
@@ -360,7 +359,7 @@ class Identity:
                 result["data"][result_data_field]
             )
         else:
-            self.opencti.log("error", "Missing parameters: type, name and description")
+            LOGGER.error("Missing parameters: type, name and description")
 
     """
         Import an Identity object from a STIX2 object
@@ -470,6 +469,4 @@ class Identity:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_identity] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_identity] Missing parameters: stixObject")

--- a/pycti/entities/opencti_incident.py
+++ b/pycti/entities/opencti_incident.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Incident:
@@ -163,9 +166,8 @@ class Incident:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Incidents with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Incidents with filters %s.", json.dumps(filters))
         query = (
             """
             query Incidents($filters: [IncidentsFiltering], $search: String, $first: Int, $after: ID, $orderBy: IncidentsOrdering, $orderMode: OrderingMode) {
@@ -216,7 +218,7 @@ class Incident:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Incident {" + id + "}.")
+            LOGGER.info("Reading Incident {%s}.", id)
             query = (
                 """
                 query Incident($id: String!) {
@@ -241,9 +243,7 @@ class Incident:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_incident] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_incident] Missing parameters: id or filters")
             return None
 
     """
@@ -278,7 +278,7 @@ class Incident:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Incident {" + name + "}.")
+            LOGGER.info("Creating Incident {%s}.", name)
             query = """
                 mutation IncidentAdd($input: IncidentAddInput) {
                     incidentAdd(input: $input) {
@@ -320,7 +320,7 @@ class Incident:
             )
             return self.opencti.process_multiple_fields(result["data"]["incidentAdd"])
         else:
-            self.opencti.log("error", "Missing parameters: name and description")
+            LOGGER.error("Missing parameters: name and description")
 
     """
         Import a Incident object from a STIX2 object
@@ -396,6 +396,4 @@ class Incident:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_incident] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_incident] Missing parameters: stixObject")

--- a/pycti/entities/opencti_infrastructure.py
+++ b/pycti/entities/opencti_infrastructure.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Infrastructure:
@@ -184,9 +187,8 @@ class Infrastructure:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Infrastructures with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Infrastructures with filters %s.", json.dumps(filters))
         query = (
             """
             query Infrastructures($filters: [InfrastructuresFiltering], $search: String, $first: Int, $after: ID, $orderBy: InfrastructuresOrdering, $orderMode: OrderingMode) {
@@ -227,7 +229,7 @@ class Infrastructure:
             final_data = final_data + data
             while result["data"]["infrastructures"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["infrastructures"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Infrastructures after " + after)
+                LOGGER.info("Listing Infrastructures after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -265,7 +267,7 @@ class Infrastructure:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Infrastructure {" + id + "}.")
+            LOGGER.info("Reading Infrastructure {%s}.", id)
             query = (
                 """
                 query Infrastructure($id: String!) {
@@ -292,9 +294,7 @@ class Infrastructure:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_infrastructure] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_infrastructure] Missing parameters: id or filters")
             return None
 
     """
@@ -326,7 +326,7 @@ class Infrastructure:
         update = kwargs.get("update", False)
 
         if name is not None:
-            self.opencti.log("info", "Creating Infrastructure {" + name + "}.")
+            LOGGER.info("Creating Infrastructure {%s}.", name)
             query = """
                 mutation InfrastructureAdd($input: InfrastructureAddInput) {
                     infrastructureAdd(input: $input) {
@@ -367,9 +367,9 @@ class Infrastructure:
                 result["data"]["infrastructureAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_infrastructure] Missing parameters: name and infrastructure_pattern and main_observable_type",
+            LOGGER.error(
+                "[opencti_infrastructure] Missing parameters: "
+                "name and infrastructure_pattern and main_observable_type"
             )
 
     """
@@ -437,6 +437,4 @@ class Infrastructure:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_intrusion_set.py
+++ b/pycti/entities/opencti_intrusion_set.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class IntrusionSet:
@@ -163,9 +166,8 @@ class IntrusionSet:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Intrusion-Sets with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Intrusion-Sets with filters %s.", json.dumps(filters))
         query = (
             """
             query IntrusionSets($filters: [IntrusionSetsFiltering], $search: String, $first: Int, $after: ID, $orderBy: IntrusionSetsOrdering, $orderMode: OrderingMode) {
@@ -216,7 +218,7 @@ class IntrusionSet:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Intrusion-Set {" + id + "}.")
+            LOGGER.info("Reading Intrusion-Set {%s}.", id)
             query = (
                 """
                 query IntrusionSet($id: String!) {
@@ -241,9 +243,7 @@ class IntrusionSet:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_intrusion_set] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_intrusion_set] Missing parameters: id or filters")
             return None
 
     """
@@ -278,7 +278,7 @@ class IntrusionSet:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Intrusion-Set {" + name + "}.")
+            LOGGER.info("Creating Intrusion-Set {%s}.", name)
             query = """
                 mutation IntrusionSetAdd($input: IntrusionSetAddInput) {
                     intrusionSetAdd(input: $input) {
@@ -322,9 +322,8 @@ class IntrusionSet:
                 result["data"]["intrusionSetAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_intrusion_set] Missing parameters: name and description",
+            LOGGER.error(
+                "[opencti_intrusion_set] Missing parameters: name and description"
             )
 
     """
@@ -403,6 +402,4 @@ class IntrusionSet:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_kill_chain_phase.py
+++ b/pycti/entities/opencti_kill_chain_phase.py
@@ -5,6 +5,8 @@ import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
 
+from pycti.entities import LOGGER
+
 
 class KillChainPhase:
     def __init__(self, opencti):
@@ -51,8 +53,8 @@ class KillChainPhase:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Kill-Chain-Phase with filters " + json.dumps(filters) + "."
+        LOGGER.info(
+            "Listing Kill-Chain-Phase with filters " + json.dumps(filters) + "."
         )
         query = (
             """
@@ -102,7 +104,7 @@ class KillChainPhase:
         id = kwargs.get("id", None)
         filters = kwargs.get("filters", None)
         if id is not None:
-            self.opencti.log("info", "Reading Kill-Chain-Phase {" + id + "}.")
+            LOGGER.info("Reading Kill-Chain-Phase {%s}.", id)
             query = (
                 """
                 query KillChainPhase($id: String!) {
@@ -125,9 +127,7 @@ class KillChainPhase:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_kill_chain_phase] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_kill_chain_phase] Missing parameters: id or filters")
             return None
 
     """
@@ -147,7 +147,7 @@ class KillChainPhase:
         update = kwargs.get("update", False)
 
         if kill_chain_name is not None and phase_name is not None:
-            self.opencti.log("info", "Creating Kill-Chain-Phase {" + phase_name + "}.")
+            LOGGER.info("Creating Kill-Chain-Phase {%s}.", phase_name)
             query = (
                 """
                 mutation KillChainPhaseAdd($input: KillChainPhaseAddInput) {
@@ -177,8 +177,7 @@ class KillChainPhase:
                 result["data"]["killChainPhaseAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_kill_chain_phase] Missing parameters: kill_chain_name and phase_name",
             )
 
@@ -194,7 +193,7 @@ class KillChainPhase:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating Kill chain {" + id + "}.")
+            LOGGER.info("Updating Kill chain {%s}.", id)
             query = """
                     mutation KillChainPhaseEdit($id: ID!, $input: [EditInput]!) {
                         killChainPhaseEdit(id: $id) {
@@ -217,16 +216,15 @@ class KillChainPhase:
                 result["data"]["killChainPhaseEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_kill_chain] Missing parameters: id and key and value",
+            LOGGER.error(
+                "[opencti_kill_chain] Missing parameters: id and key and value"
             )
             return None
 
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Kill-Chain-Phase {" + id + "}.")
+            LOGGER.info("Deleting Kill-Chain-Phase {%s}.", id)
             query = """
                  mutation KillChainPhaseEdit($id: ID!) {
                      killChainPhaseEdit(id: $id) {
@@ -236,7 +234,5 @@ class KillChainPhase:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log(
-                "error", "[opencti_kill_chain_phase] Missing parameters: id"
-            )
+            LOGGER.error("[opencti_kill_chain_phase] Missing parameters: id")
             return None

--- a/pycti/entities/opencti_label.py
+++ b/pycti/entities/opencti_label.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Label:
@@ -46,9 +49,8 @@ class Label:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Labels with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Labels with filters %s.", json.dumps(filters))
         query = (
             """
             query Labels($filters: [LabelsFiltering], $first: Int, $after: ID, $orderBy: LabelsOrdering, $orderMode: OrderingMode) {
@@ -95,7 +97,7 @@ class Label:
         id = kwargs.get("id", None)
         filters = kwargs.get("filters", None)
         if id is not None:
-            self.opencti.log("info", "Reading label {" + id + "}.")
+            LOGGER.info("Reading label {%s}.", id)
             query = (
                 """
                 query Label($id: String!) {
@@ -116,9 +118,7 @@ class Label:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_label] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_label] Missing parameters: id or filters")
             return None
 
     """
@@ -137,7 +137,7 @@ class Label:
         update = kwargs.get("update", False)
 
         if value is not None:
-            self.opencti.log("info", "Creating Label {" + value + "}.")
+            LOGGER.info("Creating Label {%s}.", value)
             query = (
                 """
                 mutation LabelAdd($input: LabelAddInput) {
@@ -163,10 +163,7 @@ class Label:
             )
             return self.opencti.process_multiple_fields(result["data"]["labelAdd"])
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_label] Missing parameters: value",
-            )
+            LOGGER.error("[opencti_label] Missing parameters: value")
 
     """
         Read or create a Label
@@ -196,7 +193,7 @@ class Label:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating Label {" + id + "}.")
+            LOGGER.info("Updating Label {%s}.", id)
             query = """
                     mutation LabelEdit($id: ID!, $input: [EditInput]!) {
                         labelEdit(id: $id) {
@@ -219,16 +216,13 @@ class Label:
                 result["data"]["labelEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_label] Missing parameters: id and key and value",
-            )
+            LOGGER.error("[opencti_label] Missing parameters: id and key and value")
             return None
 
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Label {" + id + "}.")
+            LOGGER.info("Deleting Label {%s}.", id)
             query = """
                  mutation LabelEdit($id: ID!) {
                      labelEdit(id: $id) {
@@ -238,5 +232,5 @@ class Label:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log("error", "[opencti_label] Missing parameters: id")
+            LOGGER.error("[opencti_label] Missing parameters: id")
             return None

--- a/pycti/entities/opencti_language.py
+++ b/pycti/entities/opencti_language.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Language:
@@ -156,9 +159,8 @@ class Language:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Languages with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Languages with filters %s.", json.dumps(filters))
         query = (
             """
             query Languages($filters: [LanguagesFiltering], $search: String, $first: Int, $after: ID, $orderBy: LanguagesOrdering, $orderMode: OrderingMode) {
@@ -198,7 +200,7 @@ class Language:
             final_data = final_data + data
             while result["data"]["languages"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["languages"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Languages after " + after)
+                LOGGER.info("Listing Languages after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -231,7 +233,7 @@ class Language:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Language {" + id + "}.")
+            LOGGER.info("Reading Language {%s}.", id)
             query = (
                 """
                 query Language($id: String!) {
@@ -256,9 +258,7 @@ class Language:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_language] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_language] Missing parameters: id or filters")
             return None
 
     """
@@ -286,7 +286,7 @@ class Language:
         update = kwargs.get("update", False)
 
         if name is not None:
-            self.opencti.log("info", "Creating Language {" + name + "}.")
+            LOGGER.info("Creating Language {%s}.", name)
             query = """
                 mutation LanguageAdd($input: LanguageAddInput!) {
                     languageAdd(input: $input) {
@@ -321,7 +321,7 @@ class Language:
             )
             return self.opencti.process_multiple_fields(result["data"]["languageAdd"])
         else:
-            self.opencti.log("error", "[opencti_language] Missing parameters: name")
+            LOGGER.error("[opencti_language] Missing parameters: name")
 
     """
         Import an Language object from a STIX2 object
@@ -378,6 +378,4 @@ class Language:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_language] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_language] Missing parameters: stixObject")

--- a/pycti/entities/opencti_location.py
+++ b/pycti/entities/opencti_location.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Location:
@@ -165,9 +168,8 @@ class Location:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Locations with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Locations with filters %s.", json.dumps(filters))
         query = (
             """
             query Locations($types: [String], $filters: [LocationsFiltering], $search: String, $first: Int, $after: ID, $orderBy: LocationsOrdering, $orderMode: OrderingMode) {
@@ -219,7 +221,7 @@ class Location:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Location {" + id + "}.")
+            LOGGER.info("Reading Location {%s}.", id)
             query = (
                 """
                 query Location($id: String!) {
@@ -244,9 +246,7 @@ class Location:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_location] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_location] Missing parameters: id or filters")
             return None
 
     """
@@ -278,7 +278,7 @@ class Location:
         update = kwargs.get("update", False)
 
         if name is not None:
-            self.opencti.log("info", "Creating Location {" + name + "}.")
+            LOGGER.info("Creating Location {%s}.", name)
             query = """
                 mutation LocationAdd($input: LocationAddInput) {
                     locationAdd(input: $input) {
@@ -317,7 +317,7 @@ class Location:
             )
             return self.opencti.process_multiple_fields(result["data"]["locationAdd"])
         else:
-            self.opencti.log("error", "Missing parameters: name")
+            LOGGER.error("Missing parameters: name")
 
     """
         Import an Location object from a STIX2 object
@@ -339,7 +339,7 @@ class Location:
         elif "region" in stix_object:
             name = stix_object["region"]
         else:
-            self.opencti.log("error", "[opencti_location] Missing name")
+            LOGGER.error("[opencti_location] Missing name")
             return
         if "x_opencti_location_type" in stix_object:
             type = stix_object["x_opencti_location_type"]
@@ -407,6 +407,4 @@ class Location:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_location] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_location] Missing parameters: stixObject")

--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Malware:
@@ -178,9 +181,8 @@ class Malware:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Malwares with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Malwares with filters %s.", json.dumps(filters))
         query = (
             """
             query Malwares($filters: [MalwaresFiltering], $search: String, $first: Int, $after: ID, $orderBy: MalwaresOrdering, $orderMode: OrderingMode) {
@@ -221,7 +223,7 @@ class Malware:
             final_data = final_data + data
             while result["data"]["malwares"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["malwares"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Malwares after " + after)
+                LOGGER.info("Listing Malwares after %s", after)
                 result = self.opencti.query(
                     query,
                     {
@@ -254,7 +256,7 @@ class Malware:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Malware {" + id + "}.")
+            LOGGER.info("Reading Malware {%s}.", id)
             query = (
                 """
                 query Malware($id: String!) {
@@ -279,9 +281,7 @@ class Malware:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_malware] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_malware] Missing parameters: id or filters")
             return None
 
     """
@@ -318,7 +318,7 @@ class Malware:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Malware {" + name + "}.")
+            LOGGER.info("Creating Malware {%s}.", name)
             query = """
                 mutation MalwareAdd($input: MalwareAddInput) {
                     malwareAdd(input: $input) {
@@ -362,9 +362,7 @@ class Malware:
             )
             return self.opencti.process_multiple_fields(result["data"]["malwareAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_malware] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_malware] Missing parameters: name and description")
 
     """
         Import an Malware object from a STIX2 object
@@ -450,6 +448,4 @@ class Malware:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_marking_definition.py
+++ b/pycti/entities/opencti_marking_definition.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class MarkingDefinition:
@@ -52,10 +55,10 @@ class MarkingDefinition:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info",
-            "Listing Marking-Definitions with filters " + json.dumps(filters) + ".",
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info(
+                "Listing Marking-Definitions with filters %s.", json.dumps(filters)
+            )
         query = (
             """
             query MarkingDefinitions($filters: [MarkingDefinitionsFiltering], $first: Int, $after: ID, $orderBy: MarkingDefinitionsOrdering, $orderMode: OrderingMode) {
@@ -104,7 +107,7 @@ class MarkingDefinition:
         id = kwargs.get("id", None)
         filters = kwargs.get("filters", None)
         if id is not None:
-            self.opencti.log("info", "Reading Marking-Definition {" + id + "}.")
+            LOGGER.info("Reading Marking-Definition {%s}.", id)
             query = (
                 """
                 query MarkingDefinition($id: String!) {
@@ -127,9 +130,8 @@ class MarkingDefinition:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_marking_definition] Missing parameters: id or filters",
+            LOGGER.error(
+                "[opencti_marking_definition] Missing parameters: id or filters"
             )
             return None
 
@@ -184,8 +186,7 @@ class MarkingDefinition:
                 result["data"]["markingDefinitionAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_marking_definition] Missing parameters: definition and definition_type",
             )
 
@@ -201,7 +202,7 @@ class MarkingDefinition:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating Marking Definition {" + id + "}")
+            LOGGER.info("Updating Marking Definition {%s}.", id)
             query = """
                     mutation MarkingDefinitionEdit($id: ID!, $input: [EditInput]!) {
                         markingDefinitionEdit(id: $id) {
@@ -224,9 +225,8 @@ class MarkingDefinition:
                 result["data"]["markingDefinitionEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_marking_definition] Missing parameters: id and key and value",
+            LOGGER.error(
+                "[opencti_marking_definition] Missing parameters: id and key and value"
             )
             return None
 
@@ -300,14 +300,12 @@ class MarkingDefinition:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_marking_definition] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_marking_definition] Missing parameters: stixObject")
 
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Marking-Definition {" + id + "}.")
+            LOGGER.info("Deleting Marking-Definition {%s}.", id)
             query = """
                  mutation MarkingDefinitionEdit($id: ID!) {
                      markingDefinitionEdit(id: $id) {
@@ -317,7 +315,5 @@ class MarkingDefinition:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log(
-                "error", "[opencti_marking_definition] Missing parameters: id"
-            )
+            LOGGER.error("[opencti_marking_definition] Missing parameters: id")
             return None

--- a/pycti/entities/opencti_narrative.py
+++ b/pycti/entities/opencti_narrative.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Narrative:
@@ -158,9 +161,8 @@ class Narrative:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Narratives with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Narratives with filters %s.", json.dumps(filters))
         query = (
             """
             query Narratives($filters: [NarrativesFiltering!], $search: String, $first: Int, $after: ID, $orderBy: NarrativesOrdering, $orderMode: OrderingMode) {
@@ -200,7 +202,7 @@ class Narrative:
             final_data = final_data + data
             while result["data"]["narratives"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["narratives"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Narratives after " + after)
+                LOGGER.info("Listing Narratives after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -233,7 +235,7 @@ class Narrative:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Narrative {" + id + "}.")
+            LOGGER.info("Reading Narrative {%s}.", id)
             query = (
                 """
                 query Narrative($id: String!) {
@@ -258,9 +260,7 @@ class Narrative:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_narrative] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_narrative] Missing parameters: id or filters")
             return None
 
     """
@@ -290,7 +290,7 @@ class Narrative:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Narrative {" + name + "}.")
+            LOGGER.info("Creating Narrative {%s}.", name)
             query = """
                 mutation NarrativeAdd($input: NarrativeAddInput!) {
                     narrativeAdd(input: $input) {
@@ -327,9 +327,7 @@ class Narrative:
             )
             return self.opencti.process_multiple_fields(result["data"]["narrativeAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_narrative] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_narrative] Missing parameters: name and description")
 
     """
         Import an Narrative object from a STIX2 object
@@ -394,6 +392,4 @@ class Narrative:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_narrative] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_narrative] Missing parameters: stixObject")

--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class ObservedData:
@@ -262,9 +265,8 @@ class ObservedData:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing ObservedDatas with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing ObservedDatas with filters %s.", json.dumps(filters))
         query = (
             """
             query ObservedDatas($filters: [ObservedDatasFiltering], $search: String, $first: Int, $after: ID, $orderBy: ObservedDatasOrdering, $orderMode: OrderingMode) {
@@ -315,7 +317,7 @@ class ObservedData:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading ObservedData {" + id + "}.")
+            LOGGER.info("Reading ObservedData {%s}.", id)
             query = (
                 """
                 query ObservedData($id: String!) {
@@ -352,13 +354,9 @@ class ObservedData:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Checking StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} in ObservedData {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Checking StixObjectOrStixRelationship {%s} in ObservedData {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                 query ObservedDataContainsStixObjectOrStixRelationship($id: String!, $stixObjectOrStixRelationshipId: String!) {
@@ -374,10 +372,7 @@ class ObservedData:
             )
             return result["data"]["observedDataContainsStixObjectOrStixRelationship"]
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_observedData] Missing parameters: id or entity_id",
-            )
+            LOGGER.error("[opencti_observedData] Missing parameters: id or entity_id")
 
     """
         Create a ObservedData object
@@ -410,7 +405,7 @@ class ObservedData:
             and last_observed is not None
             and objects is not None
         ):
-            self.opencti.log("info", "Creating ObservedData.")
+            LOGGER.info("Creating ObservedData.")
             query = """
                 mutation ObservedDataAdd($input: ObservedDataAddInput) {
                     observedDataAdd(input: $input) {
@@ -449,9 +444,9 @@ class ObservedData:
                 result["data"]["observedDataAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_observedData] Missing parameters: first_observed, last_observed or objects",
+            LOGGER.error(
+                "[opencti_observedData] Missing parameters: "
+                "first_observed, last_observed or objects"
             )
 
     """
@@ -473,13 +468,9 @@ class ObservedData:
                 stixObjectOrStixRelationshipId=stix_object_or_stix_relationship_id,
             ):
                 return True
-            self.opencti.log(
-                "info",
-                "Adding StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to ObservedData {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Adding StixObjectOrStixRelationship {%s} to ObservedData {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                mutation ObservedDataEdit($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -502,9 +493,9 @@ class ObservedData:
             )
             return True
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_observedData] Missing parameters: id and stix_object_or_stix_relationship_id",
+            LOGGER.error(
+                "[opencti_observedData] Missing parameters: "
+                "id and stix_object_or_stix_relationship_id"
             )
             return False
 
@@ -522,13 +513,9 @@ class ObservedData:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to Observed-Data {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing StixObjectOrStixRelationship {%s} to Observed-Data {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                mutation ObservedDataEditRelationDelete($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -549,9 +536,7 @@ class ObservedData:
             )
             return True
         else:
-            self.opencti.log(
-                "error", "[opencti_observed_data] Missing parameters: id and entity_id"
-            )
+            LOGGER.error("[opencti_observed_data] Missing parameters: id and entity_id")
             return False
 
     """
@@ -644,6 +629,4 @@ class ObservedData:
 
             return observed_data_result
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_opinion.py
+++ b/pycti/entities/opencti_opinion.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
+
+from pycti.entities import LOGGER
 
 
 class Opinion:
@@ -240,9 +243,8 @@ class Opinion:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Opinions with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Opinions with filters %s.", json.dumps(filters))
         query = (
             """
             query Opinions($filters: [OpinionsFiltering], $search: String, $first: Int, $after: ID, $orderBy: OpinionsOrdering, $orderMode: OrderingMode) {
@@ -282,7 +284,7 @@ class Opinion:
             final_data = final_data + data
             while result["data"]["opinions"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["opinions"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Opinions after " + after)
+                LOGGER.info("Listing Opinions after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -315,7 +317,7 @@ class Opinion:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Opinion {" + id + "}.")
+            LOGGER.info("Reading Opinion {%s}.", id)
             query = (
                 """
                 query Opinion($id: String!) {
@@ -352,13 +354,9 @@ class Opinion:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Checking StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} in Opinion {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Checking StixObjectOrStixRelationship {%s} in Opinion {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                 query OpinionContainsStixObjectOrStixRelationship($id: String!, $stixObjectOrStixRelationshipId: String!) {
@@ -374,10 +372,7 @@ class Opinion:
             )
             return result["data"]["opinionContainsStixObjectOrStixRelationship"]
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_opinion] Missing parameters: id or entity_id",
-            )
+            LOGGER.error("[opencti_opinion] Missing parameters: id or entity_id")
 
     """
         Create a Opinion object
@@ -406,7 +401,7 @@ class Opinion:
         update = kwargs.get("update", False)
 
         if opinion is not None:
-            self.opencti.log("info", "Creating Opinion {" + opinion + "}.")
+            LOGGER.info("Creating Opinion {%s}.", opinion)
             query = """
                 mutation OpinionAdd($input: OpinionAddInput) {
                     opinionAdd(input: $input) {
@@ -443,10 +438,7 @@ class Opinion:
             )
             return self.opencti.process_multiple_fields(result["data"]["opinionAdd"])
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_opinion] Missing parameters: content",
-            )
+            LOGGER.error("[opencti_opinion] Missing parameters: content")
 
     """
         Add a Stix-Entity object to Opinion object (object_refs)
@@ -467,13 +459,9 @@ class Opinion:
                 stixObjectOrStixRelationshipId=stix_object_or_stix_relationship_id,
             ):
                 return True
-            self.opencti.log(
-                "info",
-                "Adding StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to Opinion {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Adding StixObjectOrStixRelationship {%s} to Opinion {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                mutation OpinionEdit($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -496,8 +484,7 @@ class Opinion:
             )
             return True
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_opinion] Missing parameters: id and stix_object_or_stix_relationship_id",
             )
             return False
@@ -516,13 +503,9 @@ class Opinion:
             "stixObjectOrStixRelationshipId", None
         )
         if id is not None and stix_object_or_stix_relationship_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing StixObjectOrStixRelationship {"
-                + stix_object_or_stix_relationship_id
-                + "} to Opinion {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing StixObjectOrStixRelationship {%s} to Opinion {%s}",
+                *(stix_object_or_stix_relationship_id, id),
             )
             query = """
                mutation OpinionEditRelationDelete($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -543,9 +526,7 @@ class Opinion:
             )
             return True
         else:
-            self.opencti.log(
-                "error", "[opencti_opinion] Missing parameters: id and entity_id"
-            )
+            LOGGER.error("[opencti_opinion] Missing parameters: id and entity_id")
             return False
 
     """
@@ -611,6 +592,4 @@ class Opinion:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_stix.py
+++ b/pycti/entities/opencti_stix.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from pycti.entities import LOGGER
+
 
 class Stix:
     def __init__(self, opencti):
@@ -15,7 +17,7 @@ class Stix:
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Stix element {" + id + "}.")
+            LOGGER.info("Deleting Stix element {%s}.", id)
             query = """
                  mutation StixEdit($id: ID!) {
                      stixEdit(id: $id) {
@@ -25,7 +27,7 @@ class Stix:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log("error", "[opencti_stix] Missing parameters: id")
+            LOGGER.error("[opencti_stix] Missing parameters: id")
             return None
 
     """

--- a/pycti/entities/opencti_stix_core_object.py
+++ b/pycti/entities/opencti_stix_core_object.py
@@ -1,5 +1,8 @@
 # coding: utf-8
 import json
+import logging
+
+from pycti.entities import LOGGER
 
 
 class StixCoreObject:
@@ -390,7 +393,7 @@ class StixCoreObject:
             }
             ... on AutonomousSystem {
                 number
-                name_alt: name 
+                name_alt: name
                 rir
             }
             ... on Directory {
@@ -606,10 +609,10 @@ class StixCoreObject:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info",
-            "Listing Stix-Core-Objects with filters " + json.dumps(filters) + ".",
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info(
+                "Listing Stix-Core-Objects with filters %s.", json.dumps(filters)
+            )
         query = (
             """
                     query StixCoreObjects($types: [String], $filters: [StixCoreObjectsFiltering], $search: String, $relationship_type: [String], $elementId: String, $first: Int, $after: ID, $orderBy: StixCoreObjectsOrdering, $orderMode: OrderingMode) {
@@ -653,7 +656,7 @@ class StixCoreObject:
             final_data = final_data + data
             while result["data"]["stixCoreObjects"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["stixCoreObjects"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Stix-Core-Objects after " + after)
+                LOGGER.info("Listing Stix-Core-Objects after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -678,10 +681,7 @@ class StixCoreObject:
 
     def list_files(self, **kwargs):
         id = kwargs.get("id", None)
-        self.opencti.log(
-            "info",
-            "Listing files of Stix-Core-Object { " + id + " }",
-        )
+        LOGGER.info("Listing files of Stix-Core-Object {%s}.", id)
         query = """
                     query StixCoreObject($id: String!) {
                         stixCoreObject(id: $id) {
@@ -736,10 +736,7 @@ class StixCoreObject:
     def reports(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Getting reports of the Stix-Core-Object {" + id + "}.",
-            )
+            LOGGER.info("Getting reports of the Stix-Core-Object {%s}.", id)
             query = """
                 query StixCoreObject($id: String!) {
                     stixCoreObject(id: $id) {
@@ -863,5 +860,5 @@ class StixCoreObject:
             else:
                 return []
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return None

--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -5,6 +5,8 @@ import os
 
 import magic
 
+from pycti.entities import LOGGER
+
 
 class StixCyberObservable:
     def __init__(self, opencti, file):
@@ -347,9 +349,8 @@ class StixCyberObservable:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info",
-            "Listing StixCyberObservables with filters " + json.dumps(filters) + ".",
+        LOGGER.info(
+            "Listing StixCyberObservables with filters %s.", json.dumps(filters)
         )
         query = (
             """
@@ -392,7 +393,7 @@ class StixCyberObservable:
             final_data = final_data + data
             while result["data"]["stixCyberObservables"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["stixCyberObservables"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing StixCyberObservables after " + after)
+                LOGGER.info("Listing StixCyberObservables after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -428,7 +429,7 @@ class StixCyberObservable:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading StixCyberObservable {" + id + "}.")
+            LOGGER.info("Reading StixCyberObservable {%s}.", id)
             query = (
                 """
                     query StixCyberObservable($id: String!) {
@@ -455,9 +456,8 @@ class StixCyberObservable:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_stix_cyber_observable] Missing parameters: id or filters",
+            LOGGER.error(
+                "[opencti_stix_cyber_observable] Missing parameters: id or filters"
             )
             return None
 
@@ -493,22 +493,18 @@ class StixCyberObservable:
                     mime_type = "application/json"
                 else:
                     mime_type = magic.from_file(file_name, mime=True)
-            self.opencti.log(
-                "info",
-                "Uploading a file {"
-                + final_file_name
-                + "} in Stix-Cyber-Observable {"
-                + id
-                + "}.",
+            LOGGER.info(
+                "Uploading a file {%s} in Stix-Cyber-Observable {%s}.",
+                final_file_name,
+                id,
             )
             return self.opencti.query(
                 query,
                 {"id": id, "file": (self.file(final_file_name, data, mime_type))},
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_stix_cyber_observable Missing parameters: id or file_name",
+            LOGGER.error(
+                "[opencti_stix_cyber_observable Missing parameters: id or file_name"
             )
             return None
 
@@ -621,13 +617,10 @@ class StixCyberObservable:
                 hashes.append({"algorithm": key, "hash": value})
 
         if type is not None:
-            self.opencti.log(
-                "info",
-                "Creating Stix-Cyber-Observable {"
-                + type
-                + "} with indicator at "
-                + str(create_indicator)
-                + ".",
+            LOGGER.info(
+                "Creating Stix-Cyber-Observable {%s} with indicator at %s.",
+                type,
+                create_indicator,
             )
             input_variables = {
                 "type": type,
@@ -1165,7 +1158,7 @@ class StixCyberObservable:
                 result["data"]["stixCyberObservableAdd"]
             )
         else:
-            self.opencti.log("error", "Missing parameters: type")
+            LOGGER.error("Missing parameters: type")
 
     """
         Upload an artifact
@@ -1186,11 +1179,9 @@ class StixCyberObservable:
 
         if file_name is not None and mime_type is not None:
             final_file_name = os.path.basename(file_name)
-            self.opencti.log(
-                "info",
-                "Creating Stix-Cyber-Observable {artifact}} with indicator at "
-                + str(create_indicator)
-                + ".",
+            LOGGER.info(
+                "Creating Stix-Cyber-Observable {artifact} with indicator at %s.",
+                create_indicator,
             )
             query = """
                 mutation ArtifactImport($file: Upload!, $x_opencti_description: String, $createdBy: String, $objectMarking: [String], $objectLabel: [String]) {
@@ -1329,7 +1320,7 @@ class StixCyberObservable:
                 result["data"]["artifactImport"]
             )
         else:
-            self.opencti.log("error", "Missing parameters: type")
+            LOGGER.error("Missing parameters: type")
 
     """
         Update a Stix-Observable object field
@@ -1343,7 +1334,7 @@ class StixCyberObservable:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating Stix-Observable {" + id + "}.")
+            LOGGER.info("Updating Stix-Observable {%s}.", id)
             query = """
                 mutation StixCyberObservableEdit($id: ID!, $input: [EditInput]!) {
                     stixCyberObservableEdit(id: $id) {
@@ -1366,8 +1357,7 @@ class StixCyberObservable:
                 result["data"]["stixCyberObservableEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
+            LOGGER.error(
                 "[opencti_stix_cyber_observable_update_field] Missing parameters: id and input",
             )
             return None
@@ -1383,7 +1373,7 @@ class StixCyberObservable:
         id = kwargs.get("id", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Promoting Stix-Observable {" + id + "}.")
+            LOGGER.info("Promoting Stix-Observable {" + id + "}.")
             query = (
                 """
                     mutation StixCyberObservableEdit($id: ID!) {
@@ -1406,9 +1396,8 @@ class StixCyberObservable:
                 result["data"]["stixCyberObservableEdit"]["promote"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_stix_cyber_observable_promote] Missing parameters: id",
+            LOGGER.error(
+                "[opencti_stix_cyber_observable_promote] Missing parameters: id"
             )
             return None
 
@@ -1422,7 +1411,7 @@ class StixCyberObservable:
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting Stix-Observable {" + id + "}.")
+            LOGGER.info("Deleting Stix-Observable {%s}.", id)
             query = """
                  mutation StixCyberObservableEdit($id: ID!) {
                      stixCyberObservableEdit(id: $id) {
@@ -1432,8 +1421,8 @@ class StixCyberObservable:
              """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log(
-                "error", "[opencti_stix_cyber_observable_delete] Missing parameters: id"
+            LOGGER.error(
+                "[opencti_stix_cyber_observable_delete] Missing parameters: id"
             )
             return None
 
@@ -1449,13 +1438,10 @@ class StixCyberObservable:
         id = kwargs.get("id", None)
         identity_id = kwargs.get("identity_id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Updating author of Stix-Cyber-Observable {"
-                + id
-                + "} with Identity {"
-                + str(identity_id)
-                + "}",
+            LOGGER.info(
+                "Updating author of Stix-Cyber-Observable {%s} with Identity {%s}",
+                id,
+                identity_id,
             )
             custom_attributes = """
                 id
@@ -1520,7 +1506,7 @@ class StixCyberObservable:
                 }
                 self.opencti.query(query, variables)
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return False
 
     """
@@ -1555,20 +1541,14 @@ class StixCyberObservable:
             """
             stix_cyber_observable = self.read(id=id, customAttributes=custom_attributes)
             if stix_cyber_observable is None:
-                self.opencti.log(
-                    "error", "Cannot add Marking-Definition, entity not found"
-                )
+                LOGGER.error("Cannot add Marking-Definition, entity not found")
                 return False
             if marking_definition_id in stix_cyber_observable["objectMarkingIds"]:
                 return True
             else:
-                self.opencti.log(
-                    "info",
-                    "Adding Marking-Definition {"
-                    + marking_definition_id
-                    + "} to Stix-Cyber-Observable {"
-                    + id
-                    + "}",
+                LOGGER.info(
+                    "Adding Marking-Definition {%s} to Stix-Cyber-Observable {%s}",
+                    *(marking_definition_id, id),
                 )
                 query = """
                    mutation StixCyberObservableAddRelation($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -1591,9 +1571,7 @@ class StixCyberObservable:
                 )
                 return True
         else:
-            self.opencti.log(
-                "error", "Missing parameters: id and marking_definition_id"
-            )
+            LOGGER.error("Missing parameters: id and marking_definition_id")
             return False
 
     """
@@ -1608,13 +1586,9 @@ class StixCyberObservable:
         id = kwargs.get("id", None)
         marking_definition_id = kwargs.get("marking_definition_id", None)
         if id is not None and marking_definition_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing Marking-Definition {"
-                + marking_definition_id
-                + "} from Stix-Cyber-Observable {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing Marking-Definition {%s} from Stix-Cyber-Observable {%s}",
+                *(marking_definition_id, id),
             )
             query = """
                mutation StixCyberObservableRemoveRelation($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -1635,7 +1609,7 @@ class StixCyberObservable:
             )
             return True
         else:
-            self.opencti.log("error", "Missing parameters: id and label_id")
+            LOGGER.error("Missing parameters: id and label_id")
             return False
 
     """
@@ -1660,10 +1634,7 @@ class StixCyberObservable:
                 label = self.opencti.label.create(value=label_name)
                 label_id = label["id"]
         if id is not None and label_id is not None:
-            self.opencti.log(
-                "info",
-                "Adding label {" + label_id + "} to Stix-Cyber-Observable {" + id + "}",
-            )
+            LOGGER.info("Adding label {%s} to Stix-Cyber-Observable {%s}", label_id, id)
             query = """
                mutation StixCyberObservableAddRelation($id: ID!, $input: StixMetaRelationshipAddInput) {
                    stixCyberObservableEdit(id: $id) {
@@ -1685,7 +1656,7 @@ class StixCyberObservable:
             )
             return True
         else:
-            self.opencti.log("error", "Missing parameters: id and label_id")
+            LOGGER.error("Missing parameters: id and label_id")
             return False
 
     """
@@ -1707,13 +1678,8 @@ class StixCyberObservable:
             if label:
                 label_id = label["id"]
         if id is not None and label_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing label {"
-                + label_id
-                + "} to Stix-Cyber-Observable {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing label {%s} from Stix-Cyber-Observable {%s}", label_id, id
             )
             query = """
                mutation StixCyberObservableRemoveRelation($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -1734,7 +1700,7 @@ class StixCyberObservable:
             )
             return True
         else:
-            self.opencti.log("error", "Missing parameters: id and label_id")
+            LOGGER.error("Missing parameters: id and label_id")
             return False
 
     """
@@ -1770,20 +1736,14 @@ class StixCyberObservable:
             """
             stix_domain_object = self.read(id=id, customAttributes=custom_attributes)
             if stix_domain_object is None:
-                self.opencti.log(
-                    "error", "Cannot add External-Reference, entity not found"
-                )
+                LOGGER.error("Cannot add External-Reference, entity not found")
                 return False
             if external_reference_id in stix_domain_object["externalReferencesIds"]:
                 return True
             else:
-                self.opencti.log(
-                    "info",
-                    "Adding External-Reference {"
-                    + external_reference_id
-                    + "} to Stix-Cyber-Observable {"
-                    + id
-                    + "}",
+                LOGGER.info(
+                    "Adding External-Reference {%s} to Stix-Cyber-Observable {%s}",
+                    *(external_reference_id, id),
                 )
                 query = """
                    mutation StixCyberObservabletEditRelationAdd($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -1806,9 +1766,7 @@ class StixCyberObservable:
                 )
                 return True
         else:
-            self.opencti.log(
-                "error", "Missing parameters: id and external_reference_id"
-            )
+            LOGGER.error("Missing parameters: id and external_reference_id")
             return False
 
     """
@@ -1823,13 +1781,9 @@ class StixCyberObservable:
         id = kwargs.get("id", None)
         external_reference_id = kwargs.get("external_reference_id", None)
         if id is not None and external_reference_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing External-Reference {"
-                + external_reference_id
-                + "} to Stix-Cyber-Observable {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing External-Reference {%s} from Stix-Cyber-Observable {%s}",
+                *(external_reference_id, id),
             )
             query = """
                mutation StixCyberObservableRemoveRelation($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -1850,7 +1804,7 @@ class StixCyberObservable:
             )
             return True
         else:
-            self.opencti.log("error", "Missing parameters: id and label_id")
+            LOGGER.error("Missing parameters: id and label_id")
             return False
 
     def push_list_export(self, file_name, data, list_filters="", mime_type=None):
@@ -1876,7 +1830,7 @@ class StixCyberObservable:
         connector_id = kwargs.get("connector_id", None)
 
         if id is None or connector_id is None:
-            self.opencti.log("error", "Missing parameters: id and connector_id")
+            LOGGER.error("Missing parameters: id and connector_id")
             return ""
 
         query = """
@@ -1909,10 +1863,7 @@ class StixCyberObservable:
     def reports(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Getting reports of the Stix-Cyber-Observable {" + id + "}.",
-            )
+            LOGGER.info("Getting reports of the Stix-Cyber-Observable {%s}.", id)
             query = """
                 query StixCyberObservable($id: String!) {
                     stixCyberObservable(id: $id) {
@@ -2036,7 +1987,7 @@ class StixCyberObservable:
             else:
                 return []
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return None
 
     """
@@ -2049,10 +2000,7 @@ class StixCyberObservable:
     def notes(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Getting notes of the Stix-Cyber-Observable {" + id + "}.",
-            )
+            LOGGER.info("Getting notes of the Stix-Cyber-Observable {%s}.", id)
             query = """
                 query StixCyberObservable($id: String!) {
                     stixCyberObservable(id: $id) {
@@ -2177,7 +2125,7 @@ class StixCyberObservable:
             else:
                 return []
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return None
 
     """
@@ -2190,10 +2138,7 @@ class StixCyberObservable:
     def observed_data(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Getting Observed-Data of the Stix-Cyber-Observable {" + id + "}.",
-            )
+            LOGGER.info("Getting Observed-Data of the Stix-Cyber-Observable {%s}.", id)
             query = """
                     query StixCyberObservable($id: String!) {
                         stixCyberObservable(id: $id) {
@@ -2329,5 +2274,5 @@ class StixCyberObservable:
             else:
                 return []
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return None

--- a/pycti/entities/opencti_stix_cyber_observable_relationship.py
+++ b/pycti/entities/opencti_stix_cyber_observable_relationship.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from pycti.entities import LOGGER
+
 
 class StixCyberObservableRelationship:
     def __init__(self, opencti):
@@ -72,15 +74,9 @@ class StixCyberObservableRelationship:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info",
-            "Listing stix_observable_relationships with {type: "
-            + str(relationship_type)
-            + ", from_id: "
-            + str(from_id)
-            + ", to_id: "
-            + str(to_id)
-            + "}",
+        LOGGER.info(
+            "Listing stix_observable_relationships with {type: %s, from_id: %s, to_id: %s}",
+            *(relationship_type, from_id, to_id),
         )
         query = (
             """
@@ -156,9 +152,7 @@ class StixCyberObservableRelationship:
         stop_time_stop = kwargs.get("stopTimeStop", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log(
-                "info", "Reading stix_observable_relationship {" + id + "}."
-            )
+            LOGGER.info("Reading stix_observable_relationship {%s}.", id)
             query = (
                 """
                 query StixCyberObservableRelationship($id: String!) {
@@ -222,15 +216,9 @@ class StixCyberObservableRelationship:
         elif relationship_type == "content":
             relationship_type = "obs_content"
 
-        self.opencti.log(
-            "info",
-            "Creating stix_observable_relationship '"
-            + relationship_type
-            + "' {"
-            + from_id
-            + ", "
-            + to_id
-            + "}.",
+        LOGGER.info(
+            "Creating stix_observable_relationship '%s' {%s, %s}.",
+            *(relationship_type, from_id, to_id),
         )
         query = """
                 mutation StixCyberObservableRelationshipAdd($input: StixCyberObservableRelationshipAddInput!) {
@@ -277,10 +265,7 @@ class StixCyberObservableRelationship:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log(
-                "info",
-                "Updating stix_observable_relationship {" + id + "}.",
-            )
+            LOGGER.info("Updating stix_observable_relationship {%s}.", id)
             query = (
                 """
                 mutation StixCyberObservableRelationshipEdit($id: ID!, $input: [EditInput]!) {
@@ -299,5 +284,5 @@ class StixCyberObservableRelationship:
                 result["data"]["stixCyberObservableRelationshipEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log("error", "Missing parameters: id and key and value")
+            LOGGER.error("Missing parameters: id and key and value")
             return None

--- a/pycti/entities/opencti_stix_object_or_stix_relationship.py
+++ b/pycti/entities/opencti_stix_object_or_stix_relationship.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from pycti.entities import LOGGER
+
 
 class StixObjectOrStixRelationship:
     def __init__(self, opencti):
@@ -509,9 +511,7 @@ class StixObjectOrStixRelationship:
         id = kwargs.get("id", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log(
-                "info", "Reading StixObjectOrStixRelationship {" + id + "}."
-            )
+            LOGGER.info("Reading StixObjectOrStixRelationship {%s}.", id)
             query = (
                 """
                 query StixObjectOrStixRelationship($id: String!) {
@@ -532,5 +532,5 @@ class StixObjectOrStixRelationship:
                 result["data"]["stixObjectOrStixRelationship"]
             )
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return None

--- a/pycti/entities/opencti_stix_sighting_relationship.py
+++ b/pycti/entities/opencti_stix_sighting_relationship.py
@@ -5,6 +5,8 @@ import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
 
+from pycti.entities import LOGGER
+
 
 class StixSightingRelationship:
     def __init__(self, opencti):
@@ -326,13 +328,9 @@ class StixSightingRelationship:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info",
-            "Listing stix_sighting with {type: stix_sighting, from_id: "
-            + str(from_id)
-            + ", to_id: "
-            + str(to_id)
-            + "}",
+        LOGGER.info(
+            "Listing stix_sighting with {type: stix_sighting, from_id: %s, to_id: %s}",
+            *(from_id, to_id),
         )
         query = (
             """
@@ -387,9 +385,7 @@ class StixSightingRelationship:
                 after = result["data"]["stixSightingRelationships"]["pageInfo"][
                     "endCursor"
                 ]
-                self.opencti.log(
-                    "info", "Listing StixSightingRelationships after " + after
-                )
+                LOGGER.info("Listing StixSightingRelationships after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -443,7 +439,7 @@ class StixSightingRelationship:
         last_seen_stop = kwargs.get("lastSeenStop", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading stix_sighting {" + id + "}.")
+            LOGGER.info("Reading stix_sighting {%s}.", id)
             query = (
                 """
                     query StixSightingRelationship($id: String!) {
@@ -478,7 +474,7 @@ class StixSightingRelationship:
             else:
                 return None
         else:
-            self.opencti.log("error", "Missing parameters: id or from_id and to_id")
+            LOGGER.error("Missing parameters: id or from_id and to_id")
             return None
 
     """
@@ -507,10 +503,7 @@ class StixSightingRelationship:
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         update = kwargs.get("update", False)
 
-        self.opencti.log(
-            "info",
-            "Creating stix_sighting {" + from_id + ", " + str(to_id) + "}.",
-        )
+        LOGGER.info("Creating stix_sighting {%s, %s}.", from_id, to_id)
         query = """
                 mutation StixSightingRelationshipAdd($input: StixSightingRelationshipAddInput!) {
                     stixSightingRelationshipAdd(input: $input) {
@@ -561,7 +554,7 @@ class StixSightingRelationship:
         id = kwargs.get("id", None)
         input = kwargs.get("input", None)
         if id is not None and input is not None:
-            self.opencti.log("info", "Updating stix_sighting {" + id + "}")
+            LOGGER.info("Updating stix_sighting {%s}.", id)
             query = """
                     mutation StixSightingRelationshipEdit($id: ID!, $input: [EditInput]!) {
                         stixSightingRelationshipEdit(id: $id) {
@@ -582,9 +575,8 @@ class StixSightingRelationship:
                 result["data"]["stixSightingRelationshipEdit"]["fieldPatch"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_stix_sighting] Missing parameters: id and key and value",
+            LOGGER.error(
+                "[opencti_stix_sighting] Missing parameters: id and key and value"
             )
             return None
 
@@ -622,20 +614,14 @@ class StixSightingRelationship:
                 id=id, customAttributes=custom_attributes
             )
             if stix_core_relationship is None:
-                self.opencti.log(
-                    "error", "Cannot add Marking-Definition, entity not found"
-                )
+                LOGGER.error("Cannot add Marking-Definition, entity not found")
                 return False
             if marking_definition_id in stix_core_relationship["objectMarkingIds"]:
                 return True
             else:
-                self.opencti.log(
-                    "info",
-                    "Adding Marking-Definition {"
-                    + marking_definition_id
-                    + "} to stix_sighting_relationship {"
-                    + id
-                    + "}",
+                LOGGER.info(
+                    "Adding Marking-Definition {%s} to stix_sighting_relationship {%s}",
+                    *(marking_definition_id, id),
                 )
                 query = """
                    mutation StixSightingRelationshipEdit($id: ID!, $input: StixMetaRelationshipAddInput) {
@@ -658,9 +644,7 @@ class StixSightingRelationship:
                 )
                 return True
         else:
-            self.opencti.log(
-                "error", "Missing parameters: id and marking_definition_id"
-            )
+            LOGGER.error("Missing parameters: id and marking_definition_id")
             return False
 
     """
@@ -675,13 +659,9 @@ class StixSightingRelationship:
         id = kwargs.get("id", None)
         marking_definition_id = kwargs.get("marking_definition_id", None)
         if id is not None and marking_definition_id is not None:
-            self.opencti.log(
-                "info",
-                "Removing Marking-Definition {"
-                + marking_definition_id
-                + "} from stix_sighting_relationship {"
-                + id
-                + "}",
+            LOGGER.info(
+                "Removing Marking-Definition {%s} from stix_sighting_relationship {%s}",
+                *(marking_definition_id, id),
             )
             query = """
                mutation StixSightingRelationshipEdit($id: ID!, $toId: StixRef!, $relationship_type: String!) {
@@ -702,7 +682,7 @@ class StixSightingRelationship:
             )
             return True
         else:
-            self.opencti.log("error", "Missing parameters: id and label_id")
+            LOGGER.error("Missing parameters: id and label_id")
             return False
 
     """
@@ -717,13 +697,9 @@ class StixSightingRelationship:
         id = kwargs.get("id", None)
         identity_id = kwargs.get("identity_id", None)
         if id is not None:
-            self.opencti.log(
-                "info",
-                "Updating author of stix_sighting_relationship {"
-                + id
-                + "} with Identity {"
-                + str(identity_id)
-                + "}",
+            LOGGER.info(
+                "Updating author of stix_sighting_relationship {%s} with Identity {%s}",
+                *(id, identity_id),
             )
             custom_attributes = """
                 id
@@ -788,7 +764,7 @@ class StixSightingRelationship:
                 }
                 self.opencti.query(query, variables)
         else:
-            self.opencti.log("error", "Missing parameters: id")
+            LOGGER.error("Missing parameters: id")
             return False
 
     """
@@ -801,7 +777,7 @@ class StixSightingRelationship:
     def delete(self, **kwargs):
         id = kwargs.get("id", None)
         if id is not None:
-            self.opencti.log("info", "Deleting stix_sighting {" + id + "}.")
+            LOGGER.info("Deleting stix_sighting {%s}.", id)
             query = """
                 mutation StixSightingRelationshipEdit($id: ID!) {
                     stixSightingRelationshipEdit(id: $id) {
@@ -811,5 +787,5 @@ class StixSightingRelationship:
             """
             self.opencti.query(query, {"id": id})
         else:
-            self.opencti.log("error", "[opencti_stix_sighting] Missing parameters: id")
+            LOGGER.error("[opencti_stix_sighting] Missing parameters: id")
             return None

--- a/pycti/entities/opencti_threat_actor.py
+++ b/pycti/entities/opencti_threat_actor.py
@@ -1,10 +1,13 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 from typing import Union
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class ThreatActor:
@@ -180,9 +183,8 @@ class ThreatActor:
         if get_all:
             first = 500
 
-        self.opencti.log(
-            "info", "Listing Threat-Actors with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Threat-Actors with filters %s.", json.dumps(filters))
         query = (
             """
             query ThreatActors($filters: [ThreatActorsFiltering], $search: String, $first: Int, $after: ID, $orderBy: ThreatActorsOrdering, $orderMode: OrderingMode) {
@@ -238,7 +240,7 @@ class ThreatActor:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Threat-Actor {" + id + "}.")
+            LOGGER.info("Reading Threat-Actor {%s}.", id)
             query = (
                 """
                 query ThreatActor($id: String!) {
@@ -263,9 +265,7 @@ class ThreatActor:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_threat_actor] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_threat_actor] Missing parameters: id or filters")
             return None
 
     def create(self, **kwargs):
@@ -332,7 +332,7 @@ class ThreatActor:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Threat-Actor {" + name + "}.")
+            LOGGER.info("Creating Threat-Actor {%s}.", name)
             query = """
                 mutation ThreatActorAdd($input: ThreatActorAddInput) {
                     threatActorAdd(input: $input) {
@@ -379,9 +379,8 @@ class ThreatActor:
                 result["data"]["threatActorAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_threat_actor] Missing parameters: name and description",
+            LOGGER.error(
+                "[opencti_threat_actor] Missing parameters: name and description"
             )
 
     """
@@ -469,6 +468,4 @@ class ThreatActor:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_attack_pattern] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_attack_pattern] Missing parameters: stixObject")

--- a/pycti/entities/opencti_tool.py
+++ b/pycti/entities/opencti_tool.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Tool:
@@ -173,9 +176,8 @@ class Tool:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Tools with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Tools with filters %s.", json.dumps(filters))
         query = (
             """
             query Tools($filters: [ToolsFiltering], $search: String, $first: Int, $after: ID, $orderBy: ToolsOrdering, $orderMode: OrderingMode) {
@@ -215,7 +217,7 @@ class Tool:
             final_data = final_data + data
             while result["data"]["tools"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["tools"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Tools after " + after)
+                LOGGER.info("Listing Tools after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -248,7 +250,7 @@ class Tool:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Tool {" + id + "}.")
+            LOGGER.info("Reading Tool {%s}.", id)
             query = (
                 """
                 query Tool($id: String!) {
@@ -273,9 +275,7 @@ class Tool:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_tool] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_tool] Missing parameters: id or filters")
             return None
 
     """
@@ -306,7 +306,7 @@ class Tool:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Tool {" + name + "}.")
+            LOGGER.info("Creating Tool {%s}.", name)
             query = """
                 mutation ToolAdd($input: ToolAddInput) {
                     toolAdd(input: $input) {
@@ -344,9 +344,7 @@ class Tool:
             )
             return self.opencti.process_multiple_fields(result["data"]["toolAdd"])
         else:
-            self.opencti.log(
-                "error", "[opencti_tool] Missing parameters: name and description"
-            )
+            LOGGER.error("[opencti_tool] Missing parameters: name and description")
 
     """
         Import an Tool object from a STIX2 object
@@ -410,4 +408,4 @@ class Tool:
                 update=update,
             )
         else:
-            self.opencti.log("error", "[opencti_tool] Missing parameters: stixObject")
+            LOGGER.error("[opencti_tool] Missing parameters: stixObject")

--- a/pycti/entities/opencti_vulnerability.py
+++ b/pycti/entities/opencti_vulnerability.py
@@ -1,9 +1,12 @@
 # coding: utf-8
 
 import json
+import logging
 import uuid
 
 from stix2.canonicalization.Canonicalize import canonicalize
+
+from pycti.entities import LOGGER
 
 
 class Vulnerability:
@@ -163,9 +166,8 @@ class Vulnerability:
         if get_all:
             first = 100
 
-        self.opencti.log(
-            "info", "Listing Vulnerabilities with filters " + json.dumps(filters) + "."
-        )
+        if LOGGER.isEnabledFor(logging.INFO):
+            LOGGER.info("Listing Vulnerabilities with filters %s.", json.dumps(filters))
         query = (
             """
             query Vulnerabilities($filters: [VulnerabilitiesFiltering], $search: String, $first: Int, $after: ID, $orderBy: VulnerabilitiesOrdering, $orderMode: OrderingMode) {
@@ -206,7 +208,7 @@ class Vulnerability:
             final_data = final_data + data
             while result["data"]["vulnerabilities"]["pageInfo"]["hasNextPage"]:
                 after = result["data"]["vulnerabilities"]["pageInfo"]["endCursor"]
-                self.opencti.log("info", "Listing Vulnerabilities after " + after)
+                LOGGER.info("Listing Vulnerabilities after " + after)
                 result = self.opencti.query(
                     query,
                     {
@@ -239,7 +241,7 @@ class Vulnerability:
         filters = kwargs.get("filters", None)
         custom_attributes = kwargs.get("customAttributes", None)
         if id is not None:
-            self.opencti.log("info", "Reading Vulnerability {" + id + "}.")
+            LOGGER.info("Reading Vulnerability {%s}.", id)
             query = (
                 """
                 query Vulnerability($id: String!) {
@@ -264,9 +266,7 @@ class Vulnerability:
             else:
                 return None
         else:
-            self.opencti.log(
-                "error", "[opencti_tool] Missing parameters: id or filters"
-            )
+            LOGGER.error("[opencti_tool] Missing parameters: id or filters")
             return None
 
     """
@@ -304,7 +304,7 @@ class Vulnerability:
         update = kwargs.get("update", False)
 
         if name is not None and description is not None:
-            self.opencti.log("info", "Creating Vulnerability {" + name + "}.")
+            LOGGER.info("Creating Vulnerability {%s}.", name)
             query = """
                 mutation VulnerabilityAdd($input: VulnerabilityAddInput) {
                     vulnerabilityAdd(input: $input) {
@@ -347,9 +347,8 @@ class Vulnerability:
                 result["data"]["vulnerabilityAdd"]
             )
         else:
-            self.opencti.log(
-                "error",
-                "[opencti_vulnerability] Missing parameters: name and description",
+            LOGGER.error(
+                "[opencti_vulnerability] Missing parameters: name and description"
             )
 
     """
@@ -467,6 +466,4 @@ class Vulnerability:
                 update=update,
             )
         else:
-            self.opencti.log(
-                "error", "[opencti_vulnerability] Missing parameters: stixObject"
-            )
+            LOGGER.error("[opencti_vulnerability] Missing parameters: stixObject")

--- a/pycti/utils/opencti_stix2_update.py
+++ b/pycti/utils/opencti_stix2_update.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 
+from pycti.api import LOGGER as API_LOGGER
 from pycti.utils.constants import StixCyberObservableTypes
 
 
@@ -300,5 +301,4 @@ class OpenCTIStix2Update:
         except Exception as e:
             print(e)
             print(data)
-            self.opencti.log("error", "Cannot process this message")
-            pass
+            API_LOGGER.error("Cannot process this message")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+LOGGER = logging.getLogger(__name__)

--- a/tests/cases/connectors.py
+++ b/tests/cases/connectors.py
@@ -15,6 +15,7 @@ from pycti import (
     get_config_variable,
 )
 from pycti.utils.constants import ContainerTypes, IdentityTypes
+from tests import LOGGER
 
 
 class SimpleConnectorTest:
@@ -250,7 +251,7 @@ class InternalImportConnector:
         file_uri = self.helper.opencti_url + file_fetch
 
         # Downloading and saving file to connector
-        self.helper.log_info("Importing the file " + file_uri)
+        LOGGER.info("Importing the file %s", file_uri)
 
         # observable = SimpleObservable(
         #    id=OpenCTIStix2Utils.generate_random_stix_id("x-opencti-simple-observable"),


### PR DESCRIPTION
### Proposed changes

Current logging approach in the library does not follow best practices.
* > It is strongly advised that you do not log to the root logger in your library. Instead, use a logger with a unique and easily identifiable name, such as the __name__ for your library’s top-level package or module. Logging to the root logger will make it difficult or impossible for the application developer to configure the logging verbosity or handlers of your library as they wish. [[ref]][1]
* > Formatting of message arguments is deferred until it cannot be avoided. However, computing the arguments passed to the logging method can also be expensive, and you may want to avoid doing it if the logger will just throw away your event. [[ref]][2]
* Using custom methods for what is already provided by the logging library.

[1]: https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
[2]: https://docs.python.org/3/howto/logging.html#optimization

This change refactors logging in the whole library to follow best practices and common approach (to the best of my knowledge).
* Instead of logging to the root logger (`logging.info(...)` etc.), introduce more specific loggers, namely `pycti.api`, `pycti.connector`, and `pycti.entities` (following the higher-level modules in the library), along with a `tests` logger for the logs.
* Use the standard logger.{debug|info|error} methods, instead of unnecessary wrappers.
* Use the `%` string formatting, which is used by the logging library. This avoids unnecessary string computation in case the logging level is higher than the logging call.
* Check the logging level where expensive computation (such as `json.dumps`) might occur unnecessarily).

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I tried not to modify existing functionality, my aim was to improve the logging strategy without breaking anything.
However, I would argue that some of the logging configuration does not really belong in a library code, or at least should not be called by default, and let the users of the library configure the logging according to their needs. But for the sake of not breaking anything, I have not modified that behavior. This change should at least provide users the possibility to configure the logging levels of this library by avoiding the root logger.

Thanks in advance for your help reviewing this long PR!