### PR TITLE
[client] Add note_types and likelihood property

### DIFF
--- a/pycti/entities/opencti_note.py
+++ b/pycti/entities/opencti_note.py
@@ -112,6 +112,8 @@ class Note:
             attribute_abstract
             content
             authors
+            note_types
+            likelihood
             objects {
                 edges {
                     node {
@@ -425,6 +427,8 @@ class Note:
         abstract = kwargs.get("abstract", None)
         content = kwargs.get("content", None)
         authors = kwargs.get("authors", None)
+        note_types = kwargs.get("note_types", None)
+        likelihood = kwargs.get("likelihood", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
         update = kwargs.get("update", False)
@@ -460,6 +464,8 @@ class Note:
                         "attribute_abstract": abstract,
                         "content": content,
                         "authors": authors,
+                        "note_types": note_types,
+                        "likelihood": likelihood,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "update": update,
                     }
@@ -627,6 +633,12 @@ class Note:
                 if "x_opencti_stix_ids" in stix_object
                 else None,
                 authors=stix_object["authors"] if "authors" in stix_object else None,
+                note_types=stix_object["note_types"]
+                if "note_types" in stix_object
+                else None,
+                likelihood=stix_object["likelihood"]
+                if "likelihood" in stix_object
+                else None,
                 objectOrganization=stix_object["granted_refs"]
                 if "granted_refs" in stix_object
                 else None,

--- a/pycti/entities/opencti_stix_core_object.py
+++ b/pycti/entities/opencti_stix_core_object.py
@@ -133,6 +133,8 @@ class StixCoreObject:
                 attribute_abstract
                 content
                 authors
+                note_types
+                likelihood
             }
             ... on ObservedData {
                 first_observed

--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -2160,6 +2160,8 @@ class StixCyberObservable:
                                     attribute_abstract
                                     content
                                     authors
+                                    note_types
+                                    likelihood
                                 }
                             }
                         }

--- a/pycti/entities/opencti_stix_domain_object.py
+++ b/pycti/entities/opencti_stix_domain_object.py
@@ -144,6 +144,8 @@ class StixDomainObject:
                 attribute_abstract
                 content
                 authors
+                note_types
+                likelihood
                 objects {
                     edges {
                         node {
@@ -1560,6 +1562,8 @@ class StixDomainObject:
                                     attribute_abstract
                                     content
                                     authors
+                                    note_types
+                                    likelihood
                                 }
                             }
                         }

--- a/pycti/entities/opencti_stix_object_or_stix_relationship.py
+++ b/pycti/entities/opencti_stix_object_or_stix_relationship.py
@@ -129,6 +129,8 @@ class StixObjectOrStixRelationship:
                 attribute_abstract
                 content
                 authors
+                note_types
+                likelihood
             }
             ... on ObservedData {
                 first_observed

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -509,6 +509,8 @@ class NoteTest(EntityTest):
             "content": "You would like to know that",
             "confidence": 50,
             "authors": ["you"],
+            "note_types": ["internal"],
+            "likelihood": 75,
             #    "lang": "en",
         }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add note types and likelihood fields to Note entity

### Related issues

* [issues 309](https://github.com/OpenCTI-Platform/client-python/issues/309)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Link to OpenCTI issue : [issues 2506](https://github.com/OpenCTI-Platform/opencti/issues/2506)