### PR TITLE
Add StixObjectOrStixRelationshipLastReportsQuery

### DIFF
--- a/pycti/entities/opencti_stix_object_or_stix_relationship.py
+++ b/pycti/entities/opencti_stix_object_or_stix_relationship.py
@@ -531,3 +531,70 @@ class StixObjectOrStixRelationship:
         else:
             self.opencti.log("error", "Missing parameters: id")
             return None
+
+    def last_reports_query(self, **kwargs):
+        id = kwargs.get("id", None)
+        if id is not None:
+            self.opencti.log(
+                "info", "Reading StixObjectOrStixRelationshipLastReportsQuery {" + id + "}."
+            )
+            query = ( 
+                      """
+                query StixCoreObjectOrStixCoreRelationshipLastReportsQuery(
+                                $first: Int
+                                $orderBy: ReportsOrdering
+                                $orderMode: OrderingMode
+                                $filters: [ReportsFiltering]
+                            ) {
+                                reports(
+                                first: $first
+                                orderBy: $orderBy
+                                orderMode: $orderMode
+                                filters: $filters
+                                ) {
+                                edges {
+                                    node {
+                                    id
+                                    name
+                                    description
+                                    published
+                                    createdBy {
+                                        ... on Identity {
+                                        id
+                                        name
+                                        entity_type
+                                        }
+                                    }
+                                    objectMarking {
+                                        edges {
+                                        node {
+                                            definition
+                                        }
+                                        }
+                                    }
+                                    }
+                                }
+                                }
+                            }
+             """
+            )
+            variables = {
+                "first": 8,
+                "orderBy": "published",
+                "orderMode": "desc",
+                "filters": [
+                    {
+                        "key": "objectContains",
+                        "values": [
+                            id
+                        ]
+                    }
+                ]
+            }
+            result = self.opencti.query(query, variables)
+            return self.opencti.process_multiple_fields(
+                result["data"]["reports"]["edges"]
+            )
+        else:
+            self.opencti.log("error", "Missing parameters: id")
+            return None


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* add StixCoreObjectOrStixCoreRelationshipLastReportsQuery function to search "LATEST REPORTS ABOUT THIS ENTITY"

### Related issues

* None

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I use examples/get_observable_exact_match.py, but it can not return the association of Reports.

When I search observables, there is no way to return the Stix-Core-Objects of the previous layer, and there are no query StixCoreObjectOrStixCoreRelationshipLastReports , so I added it.
