### PR TITLE
Export only selected entities (#1741)

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1899,6 +1899,7 @@ class OpenCTIStix2:
         fromTypes: [str] = None,
         toTypes: [str] = None,
         relationship_type: [str] = None,
+        element_id: str = None,
     ) -> Dict:
         max_marking_definition_entity = (
             self.opencti.marking_definition.read(id=max_marking_definition)
@@ -1986,6 +1987,9 @@ class OpenCTIStix2:
             relationship_type=relationship_type,
         )
         if entities_list is not None:
+            if element_id:  # filtering of the data to keep those in the container
+                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                entities_list = new_entities_list
             uuids = []
             for entity in entities_list:
                 entity_bundle = self.prepare_export(
@@ -2003,6 +2007,7 @@ class OpenCTIStix2:
     def export_selected(
             self,
             entities_list: [str],
+            element_id: str = None,
             max_marking_definition: Dict = None,
     ) -> Dict:
         max_marking_definition_entity = (
@@ -2017,6 +2022,9 @@ class OpenCTIStix2:
         }
 
         if entities_list is not None:
+            if element_id:  # filtering of the data to keep those in the container
+                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                entities_list = new_entities_list
             uuids = []
             for entity in entities_list:
                 entity_bundle = self.prepare_export(

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1967,6 +1967,7 @@ class OpenCTIStix2:
             "Stix-Cyber-Observable": self.opencti.stix_cyber_observable.list,
             "stix-sighting-relationship": self.opencti.stix_sighting_relationship.list,
             "stix-core-relationship": self.opencti.stix_core_relationship.list,
+            "stix-sighting-relationship": self.opencti.stix_sighting_relationship.list,
         }
         do_list = lister.get(
             entity_type, lambda **kwargs: self.unknown_type({"type": entity_type})

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2000,6 +2000,37 @@ class OpenCTIStix2:
                     bundle["objects"] = bundle["objects"] + entity_bundle_filtered
         return bundle
 
+    def export_selected(
+            self,
+            entities_list: [str],
+            max_marking_definition: Dict = None,
+    ) -> Dict:
+        max_marking_definition_entity = (
+            self.opencti.marking_definition.read(id=max_marking_definition)
+            if max_marking_definition is not None
+            else None
+        )
+        bundle = {
+            "type": "bundle",
+            "id": "bundle--" + str(uuid.uuid4()),
+            "objects": [],
+        }
+
+        if entities_list is not None:
+            uuids = []
+            for entity in entities_list:
+                entity_bundle = self.prepare_export(
+                    self.generate_export(entity),
+                    "simple",
+                    max_marking_definition_entity,
+                )
+                if entity_bundle is not None:
+                    entity_bundle_filtered = self.filter_objects(uuids, entity_bundle)
+                    for x in entity_bundle_filtered:
+                        uuids.append(x["id"])
+                    bundle["objects"] = bundle["objects"] + entity_bundle_filtered
+        return bundle
+
     def import_bundle(
         self,
         stix_bundle: Dict,

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1967,7 +1967,6 @@ class OpenCTIStix2:
             "Stix-Cyber-Observable": self.opencti.stix_cyber_observable.list,
             "stix-sighting-relationship": self.opencti.stix_sighting_relationship.list,
             "stix-core-relationship": self.opencti.stix_core_relationship.list,
-            "stix-sighting-relationship": self.opencti.stix_sighting_relationship.list,
         }
         do_list = lister.get(
             entity_type, lambda **kwargs: self.unknown_type({"type": entity_type})
@@ -1989,8 +1988,13 @@ class OpenCTIStix2:
         )
         if entities_list is not None:
             if element_id:  # filtering of the data to keep those in the container
-                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                new_entities_list = [
+                    entity
+                    for entity in entities_list
+                    if ("objectsIds" in entity) and (element_id in entity["objectsIds"])
+                ]
                 entities_list = new_entities_list
+
             uuids = []
             for entity in entities_list:
                 entity_bundle = self.prepare_export(
@@ -2006,10 +2010,10 @@ class OpenCTIStix2:
         return bundle
 
     def export_selected(
-            self,
-            entities_list: [str],
-            element_id: str = None,
-            max_marking_definition: Dict = None,
+        self,
+        entities_list: [str],
+        element_id: str = None,
+        max_marking_definition: Dict = None,
     ) -> Dict:
         max_marking_definition_entity = (
             self.opencti.marking_definition.read(id=max_marking_definition)
@@ -2024,7 +2028,11 @@ class OpenCTIStix2:
 
         if entities_list is not None:
             if element_id:  # filtering of the data to keep those in the container
-                new_entities_list = [entity for entity in entities_list if element_id in entity["objectsIds"]]
+                new_entities_list = [
+                    entity
+                    for entity in entities_list
+                    if element_id in entity["objectsIds"]
+                ]
                 entities_list = new_entities_list
             uuids = []
             for entity in entities_list:


### PR DESCRIPTION
By default, only filters and search keywords are taken into account during the export : selecting individual entities via the checkboxes is not taken into account by the list export functions.

Steps to create the smallest reproducible scenario:

1. Select multiple observables / indicators via the check boxes
2. Open the export panels and export to CSV or JSON
3. Returned format includes all observables or indicators, not the entities selected

### Proposed changes

When we select some entities via checkboxes, the file export should only contain those entities (=entities that are checked + respect the current filtering).
If no entities are selected: the workflow stay the same as it is

### Concerned exports
- txt exports (except for relationships and single entities)
- csv exports
- stix exports

### Associated PR in connectors
https://github.com/OpenCTI-Platform/connectors/pull/1000

### Associated PR in OpenCTI
https://github.com/OpenCTI-Platform/opencti/pull/2786

### Associated issue

https://github.com/OpenCTI-Platform/opencti/issues/1741

### Notion page

https://www.notion.so/filigran/Export-only-selected-entities-1741-7fcbf649eb5a4cd6a009d4c383ce62eb

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
