### PR TITLE
[client] Iterate on snapshot of keys in OpenCTIStix2Splitter.enlist_element

### DIFF
--- a/pycti/utils/opencti_stix2_splitter.py
+++ b/pycti/utils/opencti_stix2_splitter.py
@@ -16,7 +16,8 @@ class OpenCTIStix2Splitter:
             return existing_item["nb_deps"]
         # Recursive enlist for every refs
         item = raw_data[item_id]
-        for key, value in item.items():
+        for key in list(item.keys()):
+            value = item[key]
             if key.endswith("_refs"):
                 to_keep = []
                 for element_ref in item[key]:


### PR DESCRIPTION
The (key, value) pair iterated across in the for loop in enlist_element can get out of sync with the data structure, as assignments of the form dict[key] = value, which are used inside the loop, are not guaranteed to preserve the [key] instance in-place, which could change the dictionary's .items() iteration source. To address this, put the keys in a list(), to take an independent copy of the keys that won't be altered by edits to the data structure inside of the loop. It does not appear that any attempts to delete a key occur, just set a value to None, so taking a copy to iterate off of should be safe.

### Proposed changes

In `enlist_element` change the `for key, value in item.items():` loop to `for key in list(item.keys()):` so that it iterates across a point-in-time snapshot of the keys. Inside the loop, look up the value using `dict.get(key)`.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/941

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality