### PR TITLE
[client-python] fix: update add_label query

### DIFF
--- a/pycti/entities/opencti_stix_core_relationship.py
+++ b/pycti/entities/opencti_stix_core_relationship.py
@@ -831,9 +831,9 @@ class StixCoreRelationship:
                 "Adding label {%s} to stix-core-relationship {%s}", label_id, id
             )
             query = """
-               mutation StixCoreRelationshipAddRelation($id: ID!, $input: StixRefRelationshipAddInput!) {
-                   stixCoreRelationshipEdit(id: $id) {
-                        relationAdd(input: $input) {
+               mutation StixCoreObjectLabelsViewRelationsAddMutation($id: ID!, $input: StixRefRelationshipsAddInput!) {
+                   stixCoreObjectEdit(id: $id) {
+                        relationsAdd(input: $input) {
                             id
                         }
                    }
@@ -844,7 +844,7 @@ class StixCoreRelationship:
                 {
                     "id": id,
                     "input": {
-                        "toId": label_id,
+                        "toIds": label_id,
                         "relationship_type": "object-label",
                     },
                 },


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update the GraphQL query to update label for an object.

### Related issues

```python
client.stix_core_relationship.add_label(id="df75baf4-3b25-4cd0-951b-2fdffbc23f7f", label_name="alert")
INFO:pycti.entities:Listing Labels with filters [{"key": "value", "values": ["alert"]}].
INFO:pycti.entities:Creating Label {alert}.
INFO:pycti.entities:Adding label {8f6131f5-1093-4f4c-9889-598657c4eeae} to stix-core-relationship {df75baf4-3b25-4cd0-951b-2fdffbc23f7f}
ERROR:pycti.api:Cannot add the relation, Stix-Object or Stix-Relationship cannot be found.
```

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

