### PR TITLE
Extract creators field from indicators and observables

### DIFF
--- a/pycti/entities/opencti_indicator.py
+++ b/pycti/entities/opencti_indicator.py
@@ -24,6 +24,10 @@ class Indicator:
             spec_version
             created_at
             updated_at
+            creators {
+                id
+                name
+            }
             createdBy {
                 ... on Identity {
                     id

--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -20,6 +20,10 @@ class StixCyberObservable:
             spec_version
             created_at
             updated_at
+            creators {
+                id
+                name
+            }
             createdBy {
                 ... on Identity {
                     id

--- a/tests/02-integration/entities/test_entity_crud.py
+++ b/tests/02-integration/entities/test_entity_crud.py
@@ -28,6 +28,8 @@ def test_read(entity_class):
     assert "id" in test_indicator, "No ID on object"
     assert "standard_id" in test_indicator, "No standard_id (STIX ID) on object"
     test_indicator = entity_class.own_class().read(id=test_indicator["id"])
+    if class_data.get("type") == "indicator" or "simple_observable_key" in class_data:
+        assert "creators" in test_indicator, "No creators on object"
     compare_values(
         class_data,
         test_indicator,

--- a/tests/02-integration/entities/test_entity_crud.py
+++ b/tests/02-integration/entities/test_entity_crud.py
@@ -28,8 +28,6 @@ def test_read(entity_class):
     assert "id" in test_indicator, "No ID on object"
     assert "standard_id" in test_indicator, "No standard_id (STIX ID) on object"
     test_indicator = entity_class.own_class().read(id=test_indicator["id"])
-    if class_data.get("type") == "indicator" or "simple_observable_key" in class_data:
-        assert "creators" in test_indicator, "No creators on object"
     compare_values(
         class_data,
         test_indicator,

--- a/tests/cases/entities.py
+++ b/tests/cases/entities.py
@@ -288,6 +288,10 @@ class IndicatorTest(EntityTest):
             # TODO killchain phase
         }
 
+    def get_compare_exception_keys(self) -> List[str]:
+        # indicator objects include extracted creators field
+        return ["type", "update", "createdBy", "modified", "creators"]
+
     def teardown(self):
         self.api_client.stix_domain_object.delete(id=self.organization["id"])
 
@@ -869,9 +873,11 @@ class StixCyberObservableTest(EntityTest):
         # toId = to
         # simple_observable_key = entity_type
         # simple_observable_value = observable_value & value
+        # includes extracted creators field
         return [
             "type",
             "update",
+            "creators",
             "createdBy",
             "modified",
             "simple_observable_key",


### PR DESCRIPTION
### Proposed changes

* Extract "creators" field from indicator and observable objects

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion) - nothing to update - there is no schema documented for `Inidicator` nor `StixObservable` objects
- [x] Where necessary I refactored code to improve the overall quality - not necessary within the scope of this ticket

### Further comments

If desired, I can add to this PR by extracting the creators field from all objects, not just observables and indicators.