### PR TITLE
[client] add OpenCTIMetricHandler class to handle prometheus metrics

### DIFF
--- a/pycti/__init__.py
+++ b/pycti/__init__.py
@@ -9,6 +9,7 @@ from .connector.opencti_connector_helper import (
     OpenCTIConnectorHelper,
     get_config_variable,
 )
+from .connector.opencti_metric_handler import OpenCTIMetricHandler
 from .entities.opencti_attack_pattern import AttackPattern
 from .entities.opencti_campaign import Campaign
 from .entities.opencti_case_incident import CaseIncident
@@ -97,6 +98,7 @@ __all__ = [
     "OpenCTIApiWork",
     "OpenCTIConnector",
     "OpenCTIConnectorHelper",
+    "OpenCTIMetricHandler",
     "OpenCTIStix2",
     "OpenCTIStix2Splitter",
     "OpenCTIStix2Update",

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -24,6 +24,7 @@ from pika.exceptions import NackError, UnroutableError
 from pycti.api.opencti_api_client import OpenCTIApiClient
 from pycti.connector import LOGGER
 from pycti.connector.opencti_connector import OpenCTIConnector
+from pycti.connector.opencti_metric_handler import OpenCTIMetricHandler
 from pycti.utils.opencti_stix2_splitter import OpenCTIStix2Splitter
 
 TRUTHY: List[str] = ["yes", "true", "True"]
@@ -56,6 +57,7 @@ def get_config_variable(
     :param yaml_path: path to yaml config
     :param config: client config dict, defaults to {}
     :param isNumber: specify if the variable is a number, defaults to False
+    :param default: default value
     """
 
     if os.getenv(env_var) is not None:
@@ -267,10 +269,12 @@ class ListenQueue:
                 )
             return message
         except Exception as e:  # pylint: disable=broad-except
+            self.helper.metric.inc("error_count")
             LOGGER.exception("Error in message processing, reporting error to API")
             try:
                 self.helper.api.work.to_processed(work_id, str(e), True)
             except:  # pylint: disable=bare-except
+                self.helper.metric.inc("error_count")
                 LOGGER.error("Failing reporting the processing")
 
     def run(self) -> None:
@@ -337,7 +341,7 @@ class ListenQueue:
 
 
 class PingAlive(threading.Thread):
-    def __init__(self, connector_id, api, get_state, set_state) -> None:
+    def __init__(self, connector_id, api, get_state, set_state, metric) -> None:
         threading.Thread.__init__(self)
         self.connector_id = connector_id
         self.in_error = False
@@ -345,6 +349,7 @@ class PingAlive(threading.Thread):
         self.get_state = get_state
         self.set_state = set_state
         self.exit_event = threading.Event()
+        self.metric = metric
 
     def ping(self) -> None:
         while not self.exit_event.is_set():
@@ -366,8 +371,10 @@ class PingAlive(threading.Thread):
                 if self.in_error:
                     self.in_error = False
                     LOGGER.error("API Ping back to normal")
+                self.metric.inc("ping_api_count")
             except Exception:  # pylint: disable=broad-except
                 self.in_error = True
+                self.metric.inc("ping_api_error")
                 LOGGER.error("Error pinging the API")
             self.exit_event.wait(40)
 
@@ -648,10 +655,19 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         self.connect_validate_before_import = get_config_variable(
             "CONNECTOR_VALIDATE_BEFORE_IMPORT",
             ["connector", "validate_before_import"],
+        )
+        # Start up the server to expose the metrics.
+        expose_metrics = get_config_variable(
+            "CONNECTOR_EXPOSE_METRICS",
+            ["connector", "expose_metrics"],
             config,
             False,
             False,
         )
+        metrics_port = get_config_variable(
+            "CONNECTOR_METRICS_PORT", ["connector", "metrics_port"], config, True, 9095
+        )
+        self.metric = OpenCTIMetricHandler(expose_metrics, metrics_port)
 
         # Configure logger
         logging.basicConfig(level=self.log_level)
@@ -693,7 +709,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         # Start ping thread
         if not self.connect_run_and_terminate:
             self.ping = PingAlive(
-                self.connector.id, self.api, self.get_state, self.set_state
+                self.connector.id, self.api, self.get_state, self.set_state, self.metric
             )
             self.ping.start()
 
@@ -787,6 +803,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             if initial_state != remote_state:
                 self.api.connector.ping(self.connector_id, initial_state)
         except Exception:  # pylint: disable=broad-except
+            self.metric.inc("error_count")
             LOGGER.error("Error pinging the API")
 
     def listen(self, message_callback: Callable[[Dict], str]) -> None:
@@ -974,6 +991,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             bundles = stix2_splitter.split_bundle(bundle, True, event_version)
 
         if len(bundles) == 0:
+            self.metric.inc("error_count")
             raise ValueError("Nothing to import")
 
         if work_id:
@@ -1060,8 +1078,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                     delivery_mode=2, content_encoding="utf-8"  # make message persistent
                 ),
             )
+            logging.info("Bundle has been sent")
+            self.metric.inc("bundle_send")
         except (UnroutableError, NackError) as e:
             LOGGER.error("Unable to send bundle, retry...%s", e)
+            self.metric.inc("error_count")
             self._send_bundle(channel, bundle, **kwargs)
 
     def stix2_get_embedded_objects(self, item) -> Dict:

--- a/pycti/connector/opencti_metric_handler.py
+++ b/pycti/connector/opencti_metric_handler.py
@@ -1,0 +1,115 @@
+import logging
+from typing import Type, Union
+
+from prometheus_client import Counter, Enum, start_http_server
+
+
+class OpenCTIMetricHandler:
+    def __init__(self, activated: bool = False, port: int = 9095):
+        """
+        Init of OpenCTIMetricHandler class.
+
+        Parameters
+        ----------
+        activated : bool, default False
+            If True use metrics in client and connectors.
+        port : int, default 9095
+            Port for prometheus server.
+        """
+        self.activated = activated
+
+        if self.activated:
+            logging.info(f"Exposing metrics on port {port}")
+            start_http_server(port)
+
+        self._metrics = {
+            "bundle_send": Counter(
+                "bundle_send",
+                "Number of bundle send",
+            ),
+            "record_send": Counter(
+                "record_send",
+                "Number of record (objects per bundle) send",
+            ),
+            "run_count": Counter(
+                "run_count",
+                "Number of run",
+            ),
+            "ping_api_count": Counter(
+                "ping_api_count",
+                "Number of ping to the api",
+            ),
+            "ping_api_error": Counter(
+                "ping_api_error",
+                "Number of error when pinging the api",
+            ),
+            "error_count": Counter(
+                "error_count",
+                "Number of error",
+            ),
+            "client_error_count": Counter(
+                "client_error_count",
+                "Number of client error",
+            ),
+            "state": Enum(
+                "state", "State of connector", states=["idle", "running", "stopped"]
+            ),
+        }
+
+    def _metric_exists(
+        self, name: str, expected_type: Union[Type[Counter], Type[Enum]]
+    ) -> bool:
+        """
+        Check if a metric exists and has the correct type.
+
+        If it does not, log an error and return False.
+
+        Parameters
+        ----------
+        name : str
+            Name of the metric to check.
+        expected_type : Counter or Enum
+            Expected type of the metric.
+
+        Returns
+        -------
+        bool
+            True if the metric exists and is of the correct type else False.
+        """
+        if name not in self._metrics:
+            logging.error(f"Metric {name} does not exist.")
+            return False
+        if not isinstance(self._metrics[name], expected_type):
+            logging.error(f"Metric {name} is not of expected type {expected_type}.")
+            return False
+        return True
+
+    def inc(self, name: str, n: int = 1):
+        """
+        Increment the metric (counter) `name` by `n`.
+
+        Parameters
+        ----------
+        name : str
+            Name of the metric to increment.
+        n : int, default 1
+            Increment the counter by `n`.
+        """
+        if self.activated:
+            if self._metric_exists(name, Counter):
+                self._metrics[name].inc(n)
+
+    def state(self, state: str, name: str = "state"):
+        """
+        Set the state `state` for metric `name`.
+
+        Parameters
+        ----------
+        state : str
+            State to set.
+        name : str, default = "state"
+            Name of the metric to set.
+        """
+        if self.activated:
+            if self._metric_exists(name, Enum):
+                self._metrics[name].state(state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ setuptools~=68.2.1
 filigran-sseclient~=1.0.0
 stix2~=3.0.1
 cachetools~=5.3.0
+prometheus-client~=0.13.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     datefinder~=0.7.3
     pika~=1.3.1
     python-magic~=0.4.27; sys_platform == "linux" or sys_platform == "darwin"
+    prometheus-client~=0.13.1
     python-magic-bin~=0.4.14; sys_platform == "win32"
     python_json_logger~=2.0.4
     pyyaml~=6.0

--- a/tests/01-unit/metric/test_opencti_metric_handler.py
+++ b/tests/01-unit/metric/test_opencti_metric_handler.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from prometheus_client import Counter, Enum
+
+from pycti import OpenCTIMetricHandler
+
+
+class TestOpenCTIMetricHandler(TestCase):
+    def test_metric_exists(self):
+        metric = OpenCTIMetricHandler(activated=True)
+        self.assertTrue(metric._metric_exists("error_count", Counter))
+        self.assertFalse(metric._metric_exists("error_count", Enum))
+        self.assertFalse(metric._metric_exists("best_metric_count", Counter))

--- a/tests/cases/connectors.py
+++ b/tests/cases/connectors.py
@@ -62,6 +62,8 @@ class ExternalImportConnector:
         os.environ["OPENCTI_TOKEN"] = api_client.api_token
         os.environ["OPENCTI_SSL_VERIFY"] = str(api_client.ssl_verify)
         os.environ["OPENCTI_JSON_LOGGING"] = "true"
+        os.environ["CONNECTOR_EXPOSE_METRICS"] = "true"
+        os.environ["CONNECTOR_METRICS_PORT"] = "9096"
 
         config = (
             yaml.load(open(config_file_path), Loader=yaml.FullLoader)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add a class `OpenCTIMetricHandler` to handle prometheus metrics to keep track of the number of runs, bundles sent, errors, etc.
  The class is accessible from the helper to be able to access some metrics in the connectors.
  If the env `CONNECTOR_EXPOSE_METRICS` is not set, prometheus client is not initialized.

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
