### PR TITLE
Add custom auth header to the OpenCTIApiClient session

### DIFF
--- a/docs/client_usage/getting_started.rst
+++ b/docs/client_usage/getting_started.rst
@@ -13,9 +13,10 @@ Using the helper functions
 
 The main class :class:`OpenCTIApiClient` contains all what you need to interact
 with the platform, you just have to initialize it. If your OpenCTI instance requires mTLS,
-you can specify the paths to your cert and private key in a tuple with the `cert` parameter when
-initializing the `OpenCTIApiClient`. If you need to specify a path to a CA root certificate,
-you can do so with the `ssl_verify` parameter.
+you can specify either the file path of the SSL .pem file, or provide a key-value pair representing
+the file paths to your cert and private key in a tuple with the `cert` parameter when
+initializing the `OpenCTIApiClient`. If you need to require the verification of the TLS certificate at the server,
+you can provide a boolean value for the `ssl_verify` parameter.
 
 The following example shows how you create an indicator in OpenCTI using the python library
 with TLP marking and OpenCTI compatible date format.

--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -114,6 +114,8 @@ class OpenCTIApiClient:
     :type json_logging: bool, optional
     :param cert: If String, file path to pem file. If Tuple, a ('path_to_cert.crt', 'path_to_key.key') pair representing the certificate and the key.
     :type cert: str, tuple, optional
+    :param auth: Add a AuthBase class with custom authentication for you OpenCTI infrastructure.
+    :type auth: requests.auth.AuthBase, optional
     """
 
     def __init__(
@@ -125,6 +127,7 @@ class OpenCTIApiClient:
         proxies=None,
         json_logging=False,
         cert=None,
+        auth=None,
     ):
         """Constructor method"""
 
@@ -159,7 +162,11 @@ class OpenCTIApiClient:
             "User-Agent": "pycti/" + __version__,
             "Authorization": "Bearer " + token,
         }
-        self.session = requests.session()
+
+        if auth is not None:
+            self.session = requests.session(auth=auth)
+        else:
+            self.session = requests.session()
 
         # Define the dependencies
         self.work = OpenCTIApiWork(self)

--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -100,7 +100,7 @@ class OpenCTIApiClient:
     :type token: str
     :param log_level: log level for the client
     :type log_level: str, optional
-    :param ssl_verify:
+    :param ssl_verify: Requiring the requests to verify the TLS certificate at the server.
     :type ssl_verify: bool, optional
     :param proxies:
     :type proxies: dict, optional, The proxy configuration, would have `http` and `https` attributes. Defaults to {}
@@ -112,6 +112,8 @@ class OpenCTIApiClient:
         ```
     :param json_logging: format the logs as json if set to True
     :type json_logging: bool, optional
+    :param cert: If String, file path to pem file. If Tuple, a ('path_to_cert.crt', 'path_to_key.key') pair representing the certificate and the key.
+    :type cert: str, tuple, optional
     """
 
     def __init__(


### PR DESCRIPTION
### Proposed changes

* Adds support for the AuthBase class from the requests package. This way, you can implement custom authentication logic if necessary inside the implemented OpenCTI infrastructure. This is further explained in [the docs](https://requests.readthedocs.io/en/latest/user/authentication/#new-forms-of-authentication).
* Changed the wording of the `ssl_verify` and `cert` docstrings and the related description in `getting_started.rst`.

### Related issues

* N/A.

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments
N/A.
