### PR TITLE
[client] Fix stix core objects list graphql query (#491)

### DIFF
--- a/pycti/entities/opencti_stix_core_object.py
+++ b/pycti/entities/opencti_stix_core_object.py
@@ -1350,7 +1350,7 @@ class StixCoreObject:
         LOGGER.info("Listing Stix-Core-Objects with filters %s.", json.dumps(filters))
         query = (
             """
-                    query StixCoreObjects($types: [String], $filters: [StixCoreObjectsFiltering], $search: String, $relationship_type: [String], $elementId: String, $first: Int, $after: ID, $orderBy: StixCoreObjectsOrdering, $orderMode: OrderingMode) {
+                    query StixCoreObjects($types: [String], $filters: [StixCoreObjectsFiltering], $search: String, $relationship_type: [String], $elementId: [String], $first: Int, $after: ID, $orderBy: StixCoreObjectsOrdering, $orderMode: OrderingMode) {
                         stixCoreObjects(types: $types, filters: $filters, search: $search, relationship_type: $relationship_type, elementId: $elementId, first: $first, after: $after, orderBy: $orderBy, orderMode: $orderMode) {
                             edges {
                                 node {


### PR DESCRIPTION
### Proposed changes

* Set the right type for $elementId param : [String]

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/491
* https://github.com/OpenCTI-Platform/opencti/issues/4889

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->