### PR TITLE
[client] improve error message on cannot report expectation.(#5178)

### DIFF
--- a/pycti/api/opencti_api_work.py
+++ b/pycti/api/opencti_api_work.py
@@ -55,7 +55,10 @@ class OpenCTIApiWork:
         try:
             self.api.query(query, {"id": work_id, "error": error})
         except Exception as ex:
-            self.api.log("error", "Cannot report expectation, message:" + str(ex))
+            if hasattr(ex, 'args') and len(ex.args) > 0:
+                self.api.log("error", "Cannot report expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+            else:
+                self.api.log("error", "Cannot report expectation for work_id:" + work_id)
 
     def add_expectations(self, work_id: str, expectations: int):
         LOGGER.info("Update action expectations %s - %s", work_id, expectations)
@@ -69,7 +72,10 @@ class OpenCTIApiWork:
         try:
             self.api.query(query, {"id": work_id, "expectations": expectations})
         except Exception as ex:
-            self.api.log("error", "Cannot add expectation, message:" + str(ex))
+            if hasattr(ex, 'args') and len(ex.args) > 0:
+                self.api.log("error", "Cannot add expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+            else:
+                self.api.log("error", "Cannot add expectation for work_id:" + work_id)
 
     def initiate_work(self, connector_id: str, friendly_name: str) -> str:
         LOGGER.info("Initiate work for %s", connector_id)

--- a/pycti/api/opencti_api_work.py
+++ b/pycti/api/opencti_api_work.py
@@ -55,11 +55,18 @@ class OpenCTIApiWork:
         try:
             self.api.query(query, {"id": work_id, "error": error})
         except Exception as ex:
-            if hasattr(ex, 'args') and len(ex.args) > 0:
-                self.api.log("error",
-                             "Cannot report expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+            if hasattr(ex, "args") and len(ex.args) > 0:
+                self.api.log(
+                    "error",
+                    "Cannot report expectation for work_id:"
+                    + work_id
+                    + ", message is:"
+                    + str(ex.args[0]),
+                )
             else:
-                self.api.log("error", "Cannot report expectation for work_id:" + work_id)
+                self.api.log(
+                    "error", "Cannot report expectation for work_id:" + work_id
+                )
 
     def add_expectations(self, work_id: str, expectations: int):
         LOGGER.info("Update action expectations %s - %s", work_id, expectations)
@@ -73,9 +80,14 @@ class OpenCTIApiWork:
         try:
             self.api.query(query, {"id": work_id, "expectations": expectations})
         except Exception as ex:
-            if hasattr(ex, 'args') and len(ex.args) > 0:
-                self.api.log("error",
-                             "Cannot add expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+            if hasattr(ex, "args") and len(ex.args) > 0:
+                self.api.log(
+                    "error",
+                    "Cannot add expectation for work_id:"
+                    + work_id
+                    + ", message is:"
+                    + str(ex.args[0]),
+                )
             else:
                 self.api.log("error", "Cannot add expectation for work_id:" + work_id)
 

--- a/pycti/api/opencti_api_work.py
+++ b/pycti/api/opencti_api_work.py
@@ -56,7 +56,8 @@ class OpenCTIApiWork:
             self.api.query(query, {"id": work_id, "error": error})
         except Exception as ex:
             if hasattr(ex, 'args') and len(ex.args) > 0:
-                self.api.log("error", "Cannot report expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+                self.api.log("error",
+                             "Cannot report expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
             else:
                 self.api.log("error", "Cannot report expectation for work_id:" + work_id)
 
@@ -73,7 +74,8 @@ class OpenCTIApiWork:
             self.api.query(query, {"id": work_id, "expectations": expectations})
         except Exception as ex:
             if hasattr(ex, 'args') and len(ex.args) > 0:
-                self.api.log("error", "Cannot add expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
+                self.api.log("error",
+                             "Cannot add expectation for work_id:" + work_id + ", message is:" + str(ex.args[0]))
             else:
                 self.api.log("error", "Cannot add expectation for work_id:" + work_id)
 

--- a/pycti/api/opencti_api_work.py
+++ b/pycti/api/opencti_api_work.py
@@ -54,8 +54,8 @@ class OpenCTIApiWork:
            """
         try:
             self.api.query(query, {"id": work_id, "error": error})
-        except:
-            self.api.log("error", "Cannot report expectation")
+        except Exception as ex:
+            self.api.log("error", "Cannot report expectation, message:" + str(ex))
 
     def add_expectations(self, work_id: str, expectations: int):
         LOGGER.info("Update action expectations %s - %s", work_id, expectations)
@@ -68,8 +68,8 @@ class OpenCTIApiWork:
            """
         try:
             self.api.query(query, {"id": work_id, "expectations": expectations})
-        except:
-            self.api.log("error", "Cannot report expectation")
+        except Exception as ex:
+            self.api.log("error", "Cannot add expectation, message:" + str(ex))
 
     def initiate_work(self, connector_id: str, friendly_name: str) -> str:
         LOGGER.info("Initiate work for %s", connector_id)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* In production just ":Cannot report expectation" is not enough to understand the underlying issue.

Exemple of new message (with json logs enable on config.yml):

 `{"timestamp": "2023-12-15T16:39:19.020367Z", "level": "ERROR", "name": "pycti.api", "message": "Cannot report expectation for work_id:work_import-file-stix-666_2023-12-15T16:38:54.721Z, message is:{'name': 'DatabaseError', 'message': '[SEARCH] Error loading ids'}"}`

* To avoid having long stacktrace, only the first message is taken when existing.

* Added the work_id

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5178

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
