### PR TITLE
[client] Move the logger test call present in the logger module to the test file.

### DIFF
--- a/pycti/utils/opencti_logger.py
+++ b/pycti/utils/opencti_logger.py
@@ -59,6 +59,3 @@ def logger(level, json_logging=True):
             )
 
     return AppLogger
-
-
-test_logger = logger("INFO")("test")

--- a/tests/01-unit/metric/test_opencti_metric_handler.py
+++ b/tests/01-unit/metric/test_opencti_metric_handler.py
@@ -3,11 +3,12 @@ from unittest import TestCase
 from prometheus_client import Counter, Enum
 
 from pycti import OpenCTIMetricHandler
-from pycti.utils.opencti_logger import test_logger
+from pycti.utils.opencti_logger import logger
 
 
 class TestOpenCTIMetricHandler(TestCase):
     def test_metric_exists(self):
+        test_logger = logger("INFO")("test")
         metric = OpenCTIMetricHandler(test_logger, activated=True)
         self.assertTrue(metric._metric_exists("error_count", Counter))
         self.assertFalse(metric._metric_exists("error_count", Enum))


### PR DESCRIPTION
### Proposed changes

* Move the `test_logger` call directly into the metric test.


### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/527#issuecomment-1900183738


### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- ~~[ ] I wrote test cases for the relevant uses case~~
- ~~[ ] I added/update the relevant documentation (either on github or on notion)~~
- ~~[ ] Where necessary I refactored code to improve the overall quality~~

### Further comments

Calling directly and outside any function the logger, trigger logging initialization on module import.