### PR TITLE
Add ability to disable health check

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -110,6 +110,7 @@ class OpenCTIApiClient:
         json_logging=False,
         cert=None,
         auth=None,
+        perform_health_check=True,
     ):
         """Constructor method"""
 
@@ -196,7 +197,7 @@ class OpenCTIApiClient:
         self.indicator = Indicator(self)
 
         # Check if openCTI is available
-        if not self.health_check():
+        if perform_health_check and not self.health_check():
             raise ValueError(
                 "OpenCTI API is not reachable. Waiting for OpenCTI API to start or check your configuration..."
             )


### PR DESCRIPTION

### Proposed changes

Adds an option to client constructor that enables/disables health check operation.

Health check is not always desirable, for example:

* Instantiating the client in module level will slow down application start time, which is not desirable during development.
* In local environment, the upstream OpenCTI service might not be available.

Currently this can be worked around by inheriting the client class. I thought it would be nice addition.

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

