### PR TITLE
Use `urljoin` to create API URL

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -4,6 +4,7 @@ import datetime
 import io
 import json
 from typing import Union
+from urllib.parse import urljoin
 
 import magic
 import requests
@@ -128,7 +129,7 @@ class OpenCTIApiClient:
 
         # Define API
         self.api_token = token
-        self.api_url = url + "/graphql"
+        self.api_url = urljoin(url, "/graphql")
         self.request_headers = {
             "User-Agent": "pycti/" + __version__,
             "Authorization": "Bearer " + token,


### PR DESCRIPTION
### Proposed changes

Use `urljoin` to join create API URL. If the argument has trailing slashes, this will create a proper URL.


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

