### PR TITLE
[client] Replace connect_confidence_level to None, as it will be deprecated

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -641,13 +641,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         self.connect_name = get_config_variable(
             "CONNECTOR_NAME", ["connector", "name"], config
         )
-        self.connect_confidence_level = get_config_variable(
-            "CONNECTOR_CONFIDENCE_LEVEL",
-            ["connector", "confidence_level"],
-            config,
-            True,
-            50,
-        )
+        self.connect_confidence_level = None  # Deprecated since OpenCTI version >= 6.0
         self.connect_scope = get_config_variable(
             "CONNECTOR_SCOPE", ["connector", "scope"], config
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Replace connect_confidence_level to None, as it will be deprecated

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1816

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

