### PR TITLE
[backend] Pass markings to API (#issue/5797)

### DIFF
--- a/pycti/entities/opencti_stix_domain_object.py
+++ b/pycti/entities/opencti_stix_domain_object.py
@@ -1346,11 +1346,17 @@ class StixDomainObject:
             },
         )
 
-    def push_entity_export(self, entity_id, file_name, data, mime_type=None):
+    def push_entity_export(self, entity_id, file_name, data, file_markings, mime_type=None):
         query = """
-            mutation StixDomainObjectEdit($id: ID!, $file: Upload!) {
+            mutation StixDomainObjectEdit(
+                $id: ID!, $file: Upload!,
+                $file_markings: [String]!
+            ) {
                 stixDomainObjectEdit(id: $id) {
-                    exportPush(file: $file)
+                    exportPush(
+                        file: $file,
+                        file_markings: $file_markings
+                    )
                 }
             }
         """
@@ -1358,7 +1364,13 @@ class StixDomainObject:
             file = self.file(file_name, data)
         else:
             file = self.file(file_name, data, mime_type)
-        self.opencti.query(query, {"id": entity_id, "file": file})
+        self.opencti.query(
+            query,
+            {
+                "id": entity_id,
+                "file": file,
+                "file_markings": file_markings
+            })
 
     """
         Update the Identity author of a Stix-Domain-Object object (created_by)

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -25,6 +25,7 @@ from pycti.utils.opencti_stix2_update import OpenCTIStix2Update
 from pycti.utils.opencti_stix2_utils import (
     OBSERVABLES_VALUE_INT,
     STIX_CYBER_OBSERVABLE_MAPPING,
+    OpenCTIStix2Utils,
 )
 
 datefinder.ValueError = ValueError, OverflowError

--- a/pycti/utils/opencti_stix2_utils.py
+++ b/pycti/utils/opencti_stix2_utils.py
@@ -104,7 +104,7 @@ class OpenCTIStix2Utils:
 
     @staticmethod
     def retrieveClassForMethod(
-        openCTIApiClient, entity: Dict, type_path: str, method: str
+            openCTIApiClient, entity: Dict, type_path: str, method: str
     ) -> Any:
         if entity is not None and type_path in entity:
             attributeName = entity[type_path].lower().replace("-", "_")

--- a/tests/01-unit/utils/test_opencti_stix2.py
+++ b/tests/01-unit/utils/test_opencti_stix2.py
@@ -45,12 +45,12 @@ def test_format_date_with_tz(opencti_stix2: OpenCTIStix2):
     assert my_date_str == opencti_stix2.format_date(my_date)
     assert my_datetime_str == opencti_stix2.format_date(my_datetime_str)
     assert (
-        str(
-            datetime.datetime.now(tz=datetime.timezone.utc)
-            .isoformat(timespec="seconds")
-            .replace("+00:00", "")
-        )
-        in opencti_stix2.format_date()
+            str(
+                datetime.datetime.now(tz=datetime.timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "")
+            )
+            in opencti_stix2.format_date()
     )
     with pytest.raises(ValueError):
         opencti_stix2.format_date("No time")
@@ -68,12 +68,12 @@ def test_format_date_with_tz(opencti_stix2: OpenCTIStix2):
     assert my_date_str == opencti_stix2.format_date(my_date)
     assert my_datetime_str == opencti_stix2.format_date(my_datetime_str)
     assert (
-        str(
-            datetime.datetime.now(tz=datetime.timezone.utc)
-            .isoformat(timespec="seconds")
-            .replace("+00:00", "")
-        )
-        in opencti_stix2.format_date()
+            str(
+                datetime.datetime.now(tz=datetime.timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "")
+            )
+            in opencti_stix2.format_date()
     )
     with pytest.raises(ValueError):
         opencti_stix2.format_date("No time")
@@ -104,3 +104,24 @@ def test_import_bundle_from_file(opencti_stix2: OpenCTIStix2, caplog) -> None:
     for record in caplog.records:
         assert record.levelname == "ERROR"
     assert "The bundle file does not exists" in caplog.text
+
+
+def test_check_max_marking_definition(opencti_stix2: OpenCTIStix2):
+    max_marking_definition_entity = [{'id': 'b71306ab-ee09-45ac-9fb6-93fe5bc552be',
+                                      'standard_id': 'marking-definition--5e57c739-391a-4eb3-b6be-7d15ca92d5ed',
+                                      'entity_type': 'Marking-Definition',
+                                      'parent_types': ['Basic-Object', 'Stix-Object', 'Stix-Meta-Object'],
+                                      'definition_type': 'TLP', 'definition': 'TLP:RED', 'x_opencti_order': 4,
+                                      'x_opencti_color': '#c62828', 'created': '2024-03-05T21:50:19.876Z',
+                                      'modified': '2024-03-05T21:50:19.876Z',
+                                      'created_at': '2024-03-05T21:50:19.876Z',
+                                      'updated_at': '2024-03-05T21:50:19.876Z', 'createdById': None}]
+    entity_marking_definitions = [{'id': 'd04278f2-42ad-46c3-aefe-c33bdaa29044',
+                                   'standard_id': 'marking-definition--4e4e3b84-de45-53df-9d9b-b21207699fd8',
+                                   'entity_type': 'Marking-Definition', 'definition_type': 'PAP',
+                                   'definition': 'PAP:RED', 'created': '2024-03-05T21:50:20.223Z',
+                                   'modified': '2024-03-05T21:50:20.223Z', 'x_opencti_order': 4,
+                                   'x_opencti_color': '#c62828', 'createdById': None}]
+    is_conformed_with_max_markings = opencti_stix2.check_max_marking_definition(max_marking_definition_entity,
+                                                                                entity_marking_definitions)
+    assert is_conformed_with_max_markings == False


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Update export report pdf by passing markings

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/5797

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

This pull request is related to the ones in the `Open-CTI` and `Connectors` :
* https://github.com/OpenCTI-Platform/opencti/pull/6030
* https://github.com/OpenCTI-Platform/connectors/pull/1833