### PR TITLE
Infer x_mitre_id if importing any MITRE dataset

### DIFF
--- a/pycti/entities/opencti_attack_pattern.py
+++ b/pycti/entities/opencti_attack_pattern.py
@@ -470,13 +470,7 @@ class AttackPattern:
                 )
             elif "external_references" in stix_object:
                 for external_reference in stix_object["external_references"]:
-                    if (
-                        external_reference["source_name"] == "mitre-attack"
-                        or external_reference["source_name"] == "mitre-pre-attack"
-                        or external_reference["source_name"] == "mitre-mobile-attack"
-                        or external_reference["source_name"] == "mitre-ics-attack"
-                        or external_reference["source_name"] == "amitt-attack"
-                    ):
+                    if external_reference["source_name"].startswith("mitre-"):
                         x_mitre_id = (
                             external_reference["external_id"]
                             if "external_id" in external_reference


### PR DESCRIPTION
### Proposed changes

* When inferring the `x_mitre_id` for an Attack Pattern being imported from a STIX bundle, consider the `external_id` from any External Reference with a Source that begins with "mitre-", not only the Sources specifically listed in the OpenCTI Python SDK
    * This supports [mitre-atlas dataset](https://github.com/mitre-atlas/atlas-navigator-data/blob/main/dist/stix-atlas.json) imports, which currently fail to set External ID/`x_mitre_id` when imported as a STIX Bundle.
    * Checking the source name's _prefix_ instead of its presence in a fixed list allows this import code to support all current and future MITRE datasets that include External References from sources that have similar names, starting with `"mitre-"`.

### Related issues

- https://github.com/OpenCTI-Platform/connectors/pull/1911

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

N/A
