### PR TITLE
[client] Kept report compatible with opencti relationAdd and relationDelete changes

### DIFF
--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -781,7 +781,7 @@ class Report:
                         "toId": stix_object_or_stix_relationship_id,
                         "relationship_type": "object",
                     },
-                    "commitMessage": '',
+                    "commitMessage": "",
                     "references": [],
                 },
             )
@@ -833,7 +833,7 @@ class Report:
                     "id": id,
                     "toId": stix_object_or_stix_relationship_id,
                     "relationship_type": "object",
-                    "commitMessage": '',
+                    "commitMessage": "",
                     "references": [],
                 },
             )

--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -767,7 +767,7 @@ class Report:
             query = """
                mutation ReportEditRelationAdd($id: ID!, $input: StixRefRelationshipAddInput!) {
                    reportEdit(id: $id) {
-                        relationAdd(input: $input) {
+                        relationAdd(input: $input, commitMessage: $commitMessage, references: $references) {
                             id
                         }
                    }
@@ -781,6 +781,8 @@ class Report:
                         "toId": stix_object_or_stix_relationship_id,
                         "relationship_type": "object",
                     },
+                    "commitMessage": '',
+                    "references": [],
                 },
             )
             return True
@@ -814,7 +816,12 @@ class Report:
             query = """
                mutation ReportEditRelationDelete($id: ID!, $toId: StixRef!, $relationship_type: String!) {
                    reportEdit(id: $id) {
-                        relationDelete(toId: $toId, relationship_type: $relationship_type) {
+                        relationDelete(
+                            toId: $toId, 
+                            relationship_type: $relationship_type, 
+                            commitMessage: $commitMessage, 
+                            references: $references
+                        ) {
                             id
                         }
                    }
@@ -826,6 +833,8 @@ class Report:
                     "id": id,
                     "toId": stix_object_or_stix_relationship_id,
                     "relationship_type": "object",
+                    "commitMessage": '',
+                    "references": [],
                 },
             )
             return True


### PR DESCRIPTION
Issue #5884 in opencti introduced changes to the api by adding a commit message and references as parameters to relationAdd and relationDelete to handle the "enforce references" feature.
These changes aim to keep the client compatible with these changes