### PR TITLE
[client] Added samples to malware

### DIFF
--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -108,6 +108,9 @@ class Malware:
               created
               modified
             }
+            samples {
+                id
+            }
         """
         self.properties_with_files = """
             id
@@ -220,6 +223,9 @@ class Malware:
               x_opencti_order
               created
               modified
+            }
+            samples {
+                id
             }
             importFiles {
                 edges {
@@ -411,6 +417,7 @@ class Malware:
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
         x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
+        samples = kwargs.get("samples", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -453,6 +460,7 @@ class Malware:
                         "killChainPhases": kill_chain_phases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "x_opencti_workflow_id": x_opencti_workflow_id,
+                        "samples": samples,
                         "update": update,
                     }
                 },
@@ -572,6 +580,7 @@ class Malware:
                     if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
+                samples=(extras["sample_ids"] if "sample_ids" in extras else None),
                 update=update,
             )
         else:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -770,6 +770,10 @@ class OpenCTIStix2:
             )
         elif "x_opencti_granted_refs" in stix_object:
             granted_refs_ids = stix_object["x_opencti_granted_refs"]
+        # Sample refs
+        sample_refs_ids = (
+            stix_object["sample_refs"] if "sample_refs" in stix_object else []
+        )
 
         return {
             "created_by": created_by_id,
@@ -779,6 +783,7 @@ class OpenCTIStix2:
             "kill_chain_phases": kill_chain_phases_ids,
             "object_refs": object_refs_ids,
             "granted_refs": granted_refs_ids,
+            "sample_refs": sample_refs_ids,
             "external_references": external_references_ids,
             "reports": reports,
         }
@@ -863,6 +868,7 @@ class OpenCTIStix2:
         object_refs_ids = embedded_relationships["object_refs"]
         external_references_ids = embedded_relationships["external_references"]
         reports = embedded_relationships["reports"]
+        sample_refs_ids = embedded_relationships["sample_refs"]
 
         # Extra
         extras = {
@@ -874,6 +880,7 @@ class OpenCTIStix2:
             "object_ids": object_refs_ids,
             "external_references_ids": external_references_ids,
             "reports": reports,
+            "sample_ids": sample_refs_ids,
         }
 
         # Import
@@ -1000,6 +1007,7 @@ class OpenCTIStix2:
         object_refs_ids = embedded_relationships["object_refs"]
         external_references_ids = embedded_relationships["external_references"]
         reports = embedded_relationships["reports"]
+        sample_refs_ids = embedded_relationships["sample_refs"]
 
         # Extra
         extras = {
@@ -1012,6 +1020,7 @@ class OpenCTIStix2:
             "object_ids": object_refs_ids,
             "external_references_ids": external_references_ids,
             "reports": reports,
+            "sample_ids": sample_refs_ids,
         }
         if stix_object["type"] == "simple-observable":
             stix_observable_result = self.opencti.stix_cyber_observable.create(
@@ -1176,6 +1185,7 @@ class OpenCTIStix2:
         object_refs_ids = embedded_relationships["object_refs"]
         external_references_ids = embedded_relationships["external_references"]
         reports = embedded_relationships["reports"]
+        sample_refs_ids = embedded_relationships["sample_refs"]
 
         # Extra
         extras = {
@@ -1188,6 +1198,7 @@ class OpenCTIStix2:
             "object_ids": object_refs_ids,
             "external_references_ids": external_references_ids,
             "reports": reports,
+            "sample_ids": sample_refs_ids,
         }
 
         # Create the relation
@@ -1271,6 +1282,7 @@ class OpenCTIStix2:
         object_refs_ids = embedded_relationships["object_refs"]
         external_references_ids = embedded_relationships["external_references"]
         reports = embedded_relationships["reports"]
+        sample_refs_ids = embedded_relationships["sample_refs"]
 
         # Extra
         extras = {
@@ -1283,6 +1295,7 @@ class OpenCTIStix2:
             "object_ids": object_refs_ids,
             "external_references_ids": external_references_ids,
             "reports": reports,
+            "sample_ids": sample_refs_ids,
         }
 
         # Create the sighting

--- a/tests/02-integration/entities/test_malware.py
+++ b/tests/02-integration/entities/test_malware.py
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+
+def test_malware_import_with_sample_refs(api_client):
+    with open("tests/data/basicMalwareWithSample.json", "r") as content_file:
+        content = content_file.read()
+
+    imported_malware_bundle = api_client.stix2.import_bundle_from_json(
+        json_data=content
+    )
+    assert imported_malware_bundle is not None
+
+    for importObject in imported_malware_bundle:
+        if importObject["type"] == "malware":
+            assert (
+                api_client.malware.read(id=importObject["id"]).get("samples") is not []
+            )

--- a/tests/data/basicMalwareWithSample.json
+++ b/tests/data/basicMalwareWithSample.json
@@ -1,0 +1,31 @@
+{
+    "type": "bundle",
+    "id": "bundle--59860f2d-2245-4901-b40e-46b51856bde4",
+    "objects": [
+        {
+            "id": "malware--d650c5b9-4b43-5781-8576-ea52bd6c7ce0",
+            "spec_version": "2.1",
+            "revoked": false,
+            "confidence": 100,
+            "created": "2024-03-13T09:56:18.259Z",
+            "modified": "2024-03-13T09:56:18.259Z",
+            "name": "BasicMalware",
+            "is_family": false,
+            "x_opencti_id": "75f2a512-fcc6-4cbc-a2ef-52ca9c57df46",
+            "x_opencti_type": "Malware",
+            "type": "malware",
+            "sample_refs": [
+                "file--9fb3f45e-ffce-5525-95a5-906a6695aa85"
+            ]
+        },
+        {
+            "id": "file--9fb3f45e-ffce-5525-95a5-906a6695aa85",
+            "spec_version": "2.1",
+            "x_opencti_score": 50,
+            "name": "basicFile",
+            "x_opencti_id": "8c555399-ad2c-4862-8113-0889a3c14116",
+            "x_opencti_type": "StixFile",
+            "type": "file"
+        }
+    ]
+}


### PR DESCRIPTION
Linked to openCTI PR for fixing handling of sample_refs in malware import. Tests need to run with new openCTI changes to pass

### Proposed changes

* Added samples in Malware object and applied sample_refs to imported malwares

### Related issues

* https://github.com/OpenCTI-Platform/opencti/pull/6337

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

