### PR TITLE
[client] Fixed objectLabel retrieval in reports, notes and observed data

### DIFF
--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -2349,13 +2349,9 @@ class StixCyberObservable:
                                             created
                                             modified
                                             objectLabel {
-                                                edges {
-                                                    node {
-                                                        id
-                                                        value
-                                                        color
-                                                    }
-                                                }
+                                                id
+                                                value
+                                                color
                                             }
                                         }
                                         ... on Organization {
@@ -2480,13 +2476,9 @@ class StixCyberObservable:
                                             created
                                             modified
                                             objectLabel {
-                                                edges {
-                                                    node {
-                                                        id
-                                                        value
-                                                        color
-                                                    }
-                                                }
+                                                id
+                                                value
+                                                color
                                             }
                                         }
                                         ... on Organization {
@@ -2612,13 +2604,9 @@ class StixCyberObservable:
                                                 created
                                                 modified
                                                 objectLabel {
-                                                    edges {
-                                                        node {
-                                                            id
-                                                            value
-                                                            color
-                                                        }
-                                                    }
+                                                    id
+                                                    value
+                                                    color
                                                 }
                                             }
                                             ... on Organization {

--- a/pycti/entities/opencti_stix_domain_object.py
+++ b/pycti/entities/opencti_stix_domain_object.py
@@ -1851,13 +1851,9 @@ class StixDomainObject:
                                             created
                                             modified
                                             objectLabel {
-                                                edges {
-                                                    node {
-                                                        id
-                                                        value
-                                                        color
-                                                    }
-                                                }
+                                                id
+                                                value
+                                                color
                                             }
                                         }
                                         ... on Organization {
@@ -1982,13 +1978,9 @@ class StixDomainObject:
                                             created
                                             modified
                                             objectLabel {
-                                                edges {
-                                                    node {
-                                                        id
-                                                        value
-                                                        color
-                                                    }
-                                                }
+                                                id
+                                                value
+                                                color
                                             }
                                         }
                                         ... on Organization {
@@ -2114,13 +2106,9 @@ class StixDomainObject:
                                                 created
                                                 modified
                                                 objectLabel {
-                                                    edges {
-                                                        node {
-                                                            id
-                                                            value
-                                                            color
-                                                        }
-                                                    }
+                                                    id
+                                                    value
+                                                    color
                                                 }
                                             }
                                             ... on Organization {


### PR DESCRIPTION
Fixes #587 
Fixed graphQL queries for reports, notes and observed data in stix domain object and stix cyber observable
