### PR TITLE
Move PingAlive thread to deamon to allow process exit when other processing thread are terminated (#1958)

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -185,7 +185,7 @@ class ListenQueue(threading.Thread):
         applicant_id,
         callback,
     ) -> None:
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.pika_credentials = None
         self.pika_parameters = None
         self.pika_connection = None
@@ -224,7 +224,7 @@ class ListenQueue(threading.Thread):
         channel.basic_ack(delivery_tag=method.delivery_tag)
         self.helper.connector_logger.info("Message ack", {"tag": method.delivery_tag})
 
-        self.thread = threading.Thread(target=self._data_handler, args=[json_data])
+        self.thread = threading.Thread(target=self._data_handler, args=[json_data], daemon=True)
         self.thread.start()
         five_minutes = 60 * 5
         time_wait = 0
@@ -424,7 +424,7 @@ class PingAlive(threading.Thread):
     def __init__(
         self, connector_logger, connector_id, api, get_state, set_state, metric
     ) -> None:
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.connector_logger = connector_logger
         self.connector_id = connector_id
         self.in_error = False
@@ -473,7 +473,7 @@ class PingAlive(threading.Thread):
 
 class StreamAlive(threading.Thread):
     def __init__(self, helper, q) -> None:
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.helper = helper
         self.q = q
         self.exit_event = threading.Event()
@@ -525,7 +525,7 @@ class ListenStream(threading.Thread):
         recover_iso_date,
         with_inferences,
     ) -> None:
-        threading.Thread.__init__(self)
+        threading.Thread.__init__(self, daemon=True)
         self.helper = helper
         self.callback = callback
         self.url = url

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -185,7 +185,7 @@ class ListenQueue(threading.Thread):
         applicant_id,
         callback,
     ) -> None:
-        threading.Thread.__init__(self, daemon=True)
+        threading.Thread.__init__(self)
         self.pika_credentials = None
         self.pika_parameters = None
         self.pika_connection = None
@@ -224,9 +224,7 @@ class ListenQueue(threading.Thread):
         channel.basic_ack(delivery_tag=method.delivery_tag)
         self.helper.connector_logger.info("Message ack", {"tag": method.delivery_tag})
 
-        self.thread = threading.Thread(
-            target=self._data_handler, args=[json_data], daemon=True
-        )
+        self.thread = threading.Thread(target=self._data_handler, args=[json_data])
         self.thread.start()
         five_minutes = 60 * 5
         time_wait = 0
@@ -439,7 +437,7 @@ class PingAlive(threading.Thread):
     def ping(self) -> None:
         while not self.exit_event.is_set():
             try:
-                self.connector_logger.debug("PingAlive running.")
+                self.connector_logger.info("PingAlive running.")
                 initial_state = self.get_state()
                 result = self.api.connector.ping(self.connector_id, initial_state)
                 remote_state = (
@@ -475,7 +473,7 @@ class PingAlive(threading.Thread):
 
 class StreamAlive(threading.Thread):
     def __init__(self, helper, q) -> None:
-        threading.Thread.__init__(self, daemon=True)
+        threading.Thread.__init__(self)
         self.helper = helper
         self.q = q
         self.exit_event = threading.Event()
@@ -527,7 +525,7 @@ class ListenStream(threading.Thread):
         recover_iso_date,
         with_inferences,
     ) -> None:
-        threading.Thread.__init__(self, daemon=True)
+        threading.Thread.__init__(self)
         self.helper = helper
         self.callback = callback
         self.url = url

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -224,7 +224,9 @@ class ListenQueue(threading.Thread):
         channel.basic_ack(delivery_tag=method.delivery_tag)
         self.helper.connector_logger.info("Message ack", {"tag": method.delivery_tag})
 
-        self.thread = threading.Thread(target=self._data_handler, args=[json_data], daemon=True)
+        self.thread = threading.Thread(
+            target=self._data_handler, args=[json_data], daemon=True
+        )
         self.thread.start()
         five_minutes = 60 * 5
         time_wait = 0

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -437,7 +437,7 @@ class PingAlive(threading.Thread):
     def ping(self) -> None:
         while not self.exit_event.is_set():
             try:
-                self.connector_logger.info("PingAlive running.")
+                self.connector_logger.debug("PingAlive running.")
                 initial_state = self.get_state()
                 result = self.api.connector.ping(self.connector_id, initial_state)
                 remote_state = (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Use deamon for ping alive thread, without deamon it prevents the main thread to exit when a processing thread is terminated.

### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/1958

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
