### PR TITLE
[client] Removed linked-to ref reference

### DIFF
--- a/pycti/utils/constants.py
+++ b/pycti/utils/constants.py
@@ -129,7 +129,6 @@ class MultipleRefRelationship(Enum):
     CHILD = "child"
     BODY_MULTIPART = "body-multipart"
     VALUES = "values"
-    LINKED = "x_opencti_linked-to"
     SERVICE_DDL = "service-dll"
     INSTALLED_SOFTWARE = "installed-software"
     RELATION_ANALYSIS_SCO = "analysis-sco"


### PR DESCRIPTION
Removed linked-to ref following changes to opencti
Linked to opencti [PR](https://github.com/OpenCTI-Platform/opencti/pull/6513)