### PR TITLE
python-client Fixed bug pertaining to issue #623

### DIFF
--- a/pycti/entities/opencti_case_incident.py
+++ b/pycti/entities/opencti_case_incident.py
@@ -530,7 +530,7 @@ class CaseIncident:
             data = self.opencti.process_multiple(result["data"]["caseIncidents"])
             final_data = final_data + data
             while result["data"]["caseIncidents"]["pageInfo"]["hasNextPage"]:
-                after = result["date"]["caseIncidents"]["pageInfo"]["endCursor"]
+                after = result["data"]["caseIncidents"]["pageInfo"]["endCursor"]
                 self.opencti.app_logger.info("Listing Case Incidents", {"after": after})
                 result = self.opencti.query(
                     query,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

Changing 

```
if get_all:
  final_data = []
  data = self.opencti.process_multiple(result["data"]["caseIncidents"])
  final_data = final_data + data
  while result["data"]["caseIncidents"]["pageInfo"]["hasNextPage"]:
      after = result["date"]["caseIncidents"]["pageInfo"]["endCursor"]
```

to 

```
if get_all:
  final_data = []
  data = self.opencti.process_multiple(result["data"]["caseIncidents"])
  final_data = final_data + data
  while result["data"]["caseIncidents"]["pageInfo"]["hasNextPage"]:
      after = result["data"]["caseIncidents"]["pageInfo"]["endCursor"]
```

### Related issues

See issue #623 for full bug report.
Other API entites have the same issue but in my testing they did not give an error. 
See: 

~/opencti-client-python/pycti/entities/opencti_case_rfi.py
~/opencti-client-python/pycti/entities/opencti_case_rft.py
~/opencti-client-python/pycti/entities/opencti_feedback.py
~/opencti-client-python/pycti/entities/opencti_task.py

Check the .list method for each, they all have the same `["date"]` slice.
### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case -N/A
- [ ] I added/update the relevant documentation (either on github or on notion) - N/A
- [ ] Where necessary I refactored code to improve the overall quality - N/A

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

Please correct me if I was incorrect - refer to issue #623 for my reasoning. Appears to be a simple typo issue.
