### PR TITLE
[client] Fix export an entity even if the status worfklow does not exist

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1515,7 +1515,7 @@ class OpenCTIStix2:
         if "tasks" in entity:
             del entity["tasks"]
 
-        if "status" in entity:
+        if "status" in entity and entity["status"] is not None:
             entity["x_opencti_workflow_id"] = entity["status"].get("id")
         if "status" in entity:
             del entity["status"]


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Get workflow ID only if the status is not None

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/636

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
