### PR TITLE
[client] connector helper adds custom markings to objects

### DIFF
--- a/pycti/utils/constants.py
+++ b/pycti/utils/constants.py
@@ -410,3 +410,40 @@ class CustomObservableUserAgent:
     """User-Agent observable."""
 
     pass
+
+
+# Markings for data segregation
+
+
+class DataSegregationMarking(Enum):
+    CONNECTOR = "connector"
+    AUTHOR = "author"
+
+    def definition_type(self) -> str:
+        return DataSegregationMarking.marking_prefix() + self.value
+
+    def color(self) -> str:
+        match self:
+            case self.CONNECTOR:
+                return "E0B0FF"
+            case self.AUTHOR:
+                return "BF40BF"
+
+    def default(self) -> dict:
+        match self:
+            case self.CONNECTOR:
+                return {
+                    "definition_type": self.definition_type(),
+                    "definition": "DEFAULT CONNECTOR MARKING",
+                    "x_opencti_color": self.color(),
+                }
+            case self.AUTHOR:
+                return {
+                    "definition_type": self.definition_type(),
+                    "definition": "DEFAULT AUTHOR MARKING",
+                    "x_opencti_color": self.color(),
+                }
+
+    @staticmethod
+    def marking_prefix() -> str:
+        return "source-"

--- a/tests/data/external_import_with_markings_config.yml
+++ b/tests/data/external_import_with_markings_config.yml
@@ -1,0 +1,11 @@
+connector:
+  id: '' # MUST be generated in code
+  type: 'EXTERNAL_IMPORT'
+  name: 'TestConnectorRegisteringMarkings' # MUST be suffixed in code by id
+  scope: 'identity,malware'
+  confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
+  update_existing_data: True
+  log_level: 'debug'
+
+test:
+  interval: 1


### PR DESCRIPTION
Custom markings can be used to enforce data segregation on objects.

Open points:

- [ ] Are names (both for connector and author) considered unique? i.e can the marking definition contain only the name instead of the name + id tuple
- [ ] Should the `identity` entities be exempt from author markings?

Notes on testing:
- Set OpenCTI URL and token in `test/conftest.py`
- Run test with `--connectors`