### PR TITLE
Take in account env variable SSL_VERIFY when instantiate OpenCTIApiClient (#598)

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -665,7 +665,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             "OPENCTI_TOKEN", ["opencti", "token"], config
         )
         self.opencti_ssl_verify = get_config_variable(
-            "OPENCTI_SSL_VERIFY", ["opencti", "ssl_verify"], config, False, True
+            "OPENCTI_SSL_VERIFY", ["opencti", "ssl_verify"], config, False, False
         )
         self.opencti_json_logging = get_config_variable(
             "OPENCTI_JSON_LOGGING", ["opencti", "json_logging"], config, False, True

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -793,6 +793,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.opencti_url,
             self.opencti_token,
             self.log_level,
+            self.opencti_ssl_verify,
             json_logging=self.opencti_json_logging,
             bundle_send_to_queue=self.bundle_send_to_queue,
         )
@@ -802,6 +803,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.opencti_url,
             self.opencti_token,
             self.log_level,
+            self.opencti_ssl_verify,
             json_logging=self.opencti_json_logging,
             bundle_send_to_queue=self.bundle_send_to_queue,
         )


### PR DESCRIPTION
### Proposed changes

* take in account env variable SSL_VERIFY when instantiate OpenCTIApiClient

### Related issues

* #598 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

I don't know how to test locally and the impact it has to make such a modification. Please do not merge for now.
