### PR TITLE
[client] Prevent IndexError when reading Case-Incident in OpenCTIConnectorHelper

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -315,7 +315,9 @@ class ListenQueue(threading.Thread):
                         e
                         for e in stix_objects
                         if e["id"] == opencti_entity["standard_id"]
-                    ][0]
+                    ]
+                    if stix_entity:
+                        stix_entity = stix_entity[0]
                     event_data["stix_objects"] = stix_objects
                     event_data["stix_entity"] = stix_entity
                 # Handle organization propagation


### PR DESCRIPTION
**_data_handler** in **opencti_connector_helper.py** raises error "**IndexError: list index out of range**" when reading a **Case-Incident**