### PR TITLE
[client] add status x_opencti_workflow_id in relationship stix import (#opencti/7114)

### DIFF
--- a/pycti/entities/opencti_attack_pattern.py
+++ b/pycti/entities/opencti_attack_pattern.py
@@ -395,6 +395,7 @@ class AttackPattern:
         kill_chain_phases = kwargs.get("killChainPhases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -433,6 +434,7 @@ class AttackPattern:
                         "x_mitre_id": x_mitre_id,
                         "killChainPhases": kill_chain_phases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -511,6 +513,10 @@ class AttackPattern:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -577,6 +583,11 @@ class AttackPattern:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_campaign.py
+++ b/pycti/entities/opencti_campaign.py
@@ -376,6 +376,7 @@ class Campaign:
         objective = kwargs.get("objective", None)
         granted_refs = kwargs.get("objectOrganization", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -412,6 +413,7 @@ class Campaign:
                         "last_seen": last_seen,
                         "objective": objective,
                         "update": update,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                     }
                 },
@@ -442,6 +444,10 @@ class Campaign:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(
@@ -493,6 +499,11 @@ class Campaign:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_case_rfi.py
+++ b/pycti/entities/opencti_case_rfi.py
@@ -680,6 +680,7 @@ class CaseRfi:
         description = kwargs.get("description", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
         information_types = kwargs.get("information_types", None)
 
@@ -714,6 +715,7 @@ class CaseRfi:
                         "name": name,
                         "description": description,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                         "information_types": information_types,
                     }
@@ -836,6 +838,10 @@ class CaseRfi:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -877,6 +883,11 @@ class CaseRfi:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_case_rft.py
+++ b/pycti/entities/opencti_case_rft.py
@@ -679,6 +679,7 @@ class CaseRft:
         description = kwargs.get("description", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
         takedown_types = kwargs.get("takedown_types", None)
 
@@ -713,6 +714,7 @@ class CaseRft:
                         "name": name,
                         "description": description,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                         "takedown_types": takedown_types,
                     }
@@ -835,6 +837,12 @@ class CaseRft:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension(
+                        "workflow_id", stix_object
+                    )
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -881,6 +889,11 @@ class CaseRft:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_case_rft.py
+++ b/pycti/entities/opencti_case_rft.py
@@ -839,9 +839,7 @@ class CaseRft:
                 )
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "workflow_id", stix_object
-                    )
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(

--- a/pycti/entities/opencti_course_of_action.py
+++ b/pycti/entities/opencti_course_of_action.py
@@ -367,6 +367,7 @@ class CourseOfAction:
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         x_mitre_id = kwargs.get("x_mitre_id", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -401,6 +402,7 @@ class CourseOfAction:
                         "x_opencti_aliases": x_opencti_aliases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "x_mitre_id": x_mitre_id,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -459,6 +461,10 @@ class CourseOfAction:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -501,6 +507,11 @@ class CourseOfAction:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_data_component.py
+++ b/pycti/entities/opencti_data_component.py
@@ -406,6 +406,7 @@ class DataComponent:
         aliases = kwargs.get("aliases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -443,6 +444,7 @@ class DataComponent:
                         "aliases": aliases,
                         "dataSource": dataSource,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -489,6 +491,10 @@ class DataComponent:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.opencti.data_component.create(
                 stix_id=stix_object["id"],
@@ -533,6 +539,11 @@ class DataComponent:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_data_source.py
+++ b/pycti/entities/opencti_data_source.py
@@ -363,6 +363,7 @@ class DataSource:
         collection_layers = kwargs.get("collection_layers", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -399,6 +400,7 @@ class DataSource:
                         "x_mitre_platforms": platforms,
                         "collection_layers": collection_layers,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -444,6 +446,10 @@ class DataSource:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.opencti.data_source.create(
@@ -494,6 +500,11 @@ class DataSource:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_feedback.py
+++ b/pycti/entities/opencti_feedback.py
@@ -645,6 +645,7 @@ class Feedback:
         rating = kwargs.get("rating", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -679,6 +680,7 @@ class Feedback:
                         "description": description,
                         "rating": rating,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -828,6 +830,10 @@ class Feedback:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -870,6 +876,11 @@ class Feedback:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_grouping.py
+++ b/pycti/entities/opencti_grouping.py
@@ -624,6 +624,7 @@ class Grouping:
         x_opencti_aliases = kwargs.get("x_opencti_aliases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None and context is not None:
@@ -659,6 +660,7 @@ class Grouping:
                         "description": description,
                         "x_opencti_aliases": x_opencti_aliases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -776,6 +778,10 @@ class Grouping:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -821,6 +827,11 @@ class Grouping:
                     else None
                 ),
                 x_opencti_aliases=self.opencti.stix2.pick_aliases(stix_object),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
+                    else None
+                ),
                 update=update,
             )
         else:

--- a/pycti/entities/opencti_identity.py
+++ b/pycti/entities/opencti_identity.py
@@ -542,9 +542,7 @@ class Identity:
                 )
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "workflow_id", stix_object
-                    )
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(

--- a/pycti/entities/opencti_identity.py
+++ b/pycti/entities/opencti_identity.py
@@ -543,7 +543,7 @@ class Identity:
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
                     self.opencti.get_attribute_in_extension(
-                        "x_opencti_workflow_id", stix_object
+                        "workflow_id", stix_object
                     )
                 )
 

--- a/pycti/entities/opencti_infrastructure.py
+++ b/pycti/entities/opencti_infrastructure.py
@@ -416,6 +416,7 @@ class Infrastructure:
         kill_chain_phases = kwargs.get("killChainPhases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -453,6 +454,7 @@ class Infrastructure:
                         "last_seen": last_seen,
                         "killChainPhases": kill_chain_phases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -486,6 +488,10 @@ class Infrastructure:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(
@@ -544,6 +550,11 @@ class Infrastructure:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_location.py
+++ b/pycti/entities/opencti_location.py
@@ -350,6 +350,7 @@ class Location:
         precision = kwargs.get("precision", None)
         x_opencti_aliases = kwargs.get("x_opencti_aliases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -386,6 +387,7 @@ class Location:
                         "precision": precision,
                         "x_opencti_aliases": x_opencti_aliases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -439,6 +441,10 @@ class Location:
                 stix_object["x_opencti_stix_ids"] = (
                     self.opencti.get_attribute_in_extension("stix_ids", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 type=type,
@@ -485,6 +491,11 @@ class Location:
                     else None
                 ),
                 x_opencti_aliases=self.opencti.stix2.pick_aliases(stix_object),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
+                    else None
+                ),
                 update=update,
             )
         else:

--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -495,7 +495,7 @@ class Malware:
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
                     self.opencti.get_attribute_in_extension(
-                        "x_opencti_workflow_id", stix_object
+                        "workflow_id", stix_object
                     )
                 )
 

--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -494,9 +494,7 @@ class Malware:
                 )
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "workflow_id", stix_object
-                    )
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(

--- a/pycti/entities/opencti_narrative.py
+++ b/pycti/entities/opencti_narrative.py
@@ -360,6 +360,7 @@ class Narrative:
         narrative_types = kwargs.get("narrative_types", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -394,6 +395,7 @@ class Narrative:
                         "aliases": aliases,
                         "narrative_types": narrative_types,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -424,6 +426,10 @@ class Narrative:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.opencti.narrative.create(
@@ -471,6 +477,11 @@ class Narrative:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_note.py
+++ b/pycti/entities/opencti_note.py
@@ -636,6 +636,7 @@ class Note:
         likelihood = kwargs.get("likelihood", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if content is not None:
@@ -672,6 +673,7 @@ class Note:
                         "note_types": note_types,
                         "likelihood": likelihood,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -798,6 +800,10 @@ class Note:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],
@@ -850,6 +856,11 @@ class Note:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -607,6 +607,7 @@ class ObservedData:
         number_observed = kwargs.get("number_observed", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if (
@@ -645,6 +646,7 @@ class ObservedData:
                         "last_observed": last_observed,
                         "number_observed": number_observed,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -810,6 +812,10 @@ class ObservedData:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             observed_data_result = self.create(
                 stix_id=stix_object["id"],
@@ -860,6 +866,11 @@ class ObservedData:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_stix_core_relationship.py
+++ b/pycti/entities/opencti_stix_core_relationship.py
@@ -1135,6 +1135,12 @@ class StixCoreRelationship:
                         "granted_refs", stix_relation
                     )
                 )
+            if "x_opencti_workflow_id" not in stix_relation:
+                stix_relation["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension(
+                        "workflow_id", stix_relation
+                    )
+                )
 
             source_ref = stix_relation["source_ref"]
             target_ref = stix_relation["target_ref"]

--- a/pycti/entities/opencti_stix_sighting_relationship.py
+++ b/pycti/entities/opencti_stix_sighting_relationship.py
@@ -501,6 +501,7 @@ class StixSightingRelationship:
         object_label = kwargs.get("objectLabel", None)
         external_references = kwargs.get("externalReferences", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         self.opencti.app_logger.info(
@@ -536,6 +537,7 @@ class StixSightingRelationship:
                     "objectLabel": object_label,
                     "externalReferences": external_references,
                     "x_opencti_stix_ids": x_opencti_stix_ids,
+                    "x_opencti_workflow_id": x_opencti_workflow_id,
                     "update": update,
                 }
             },

--- a/pycti/entities/opencti_task.py
+++ b/pycti/entities/opencti_task.py
@@ -619,9 +619,7 @@ class Task:
                 )
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "workflow_id", stix_object
-                    )
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
             if "x_opencti_assignee_ids" not in stix_object:
                 stix_object["x_opencti_assignee_ids"] = (

--- a/pycti/entities/opencti_task.py
+++ b/pycti/entities/opencti_task.py
@@ -620,7 +620,7 @@ class Task:
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
                     self.opencti.get_attribute_in_extension(
-                        "x_opencti_workflow_id", stix_object
+                        "workflow_id", stix_object
                     )
                 )
             if "x_opencti_assignee_ids" not in stix_object:

--- a/pycti/entities/opencti_threat_actor_group.py
+++ b/pycti/entities/opencti_threat_actor_group.py
@@ -324,6 +324,7 @@ class ThreatActorGroup:
         personal_motivations = kwargs.get("personal_motivations", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -366,6 +367,7 @@ class ThreatActorGroup:
                         "secondary_motivations": secondary_motivations,
                         "personal_motivations": personal_motivations,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -398,6 +400,10 @@ class ThreatActorGroup:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(
@@ -477,6 +483,11 @@ class ThreatActorGroup:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_threat_actor_individual.py
+++ b/pycti/entities/opencti_threat_actor_individual.py
@@ -404,15 +404,9 @@ class ThreatActorIndividual:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
-            if "x_opencti_reliability" not in stix_object:
-                stix_object["x_opencti_reliability"] = (
-                    self.opencti.get_attribute_in_extension("reliability", stix_object)
-                )
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "workflow_id", stix_object
-                    )
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.create(

--- a/pycti/entities/opencti_threat_actor_individual.py
+++ b/pycti/entities/opencti_threat_actor_individual.py
@@ -325,6 +325,7 @@ class ThreatActorIndividual:
         personal_motivations = kwargs.get("personal_motivations", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -369,6 +370,7 @@ class ThreatActorIndividual:
                         "secondary_motivations": secondary_motivations,
                         "personal_motivations": personal_motivations,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -401,6 +403,10 @@ class ThreatActorIndividual:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_reliability" not in stix_object:
+                stix_object["x_opencti_reliability"] = (
+                    self.opencti.get_attribute_in_extension("reliability", stix_object)
                 )
 
             return self.create(
@@ -480,6 +486,11 @@ class ThreatActorIndividual:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_threat_actor_individual.py
+++ b/pycti/entities/opencti_threat_actor_individual.py
@@ -408,6 +408,12 @@ class ThreatActorIndividual:
                 stix_object["x_opencti_reliability"] = (
                     self.opencti.get_attribute_in_extension("reliability", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension(
+                        "workflow_id", stix_object
+                    )
+                )
 
             return self.create(
                 stix_id=stix_object["id"],

--- a/pycti/entities/opencti_tool.py
+++ b/pycti/entities/opencti_tool.py
@@ -288,6 +288,7 @@ class Tool:
         kill_chain_phases = kwargs.get("killChainPhases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -324,6 +325,7 @@ class Tool:
                         "tool_version": tool_version,
                         "killChainPhases": kill_chain_phases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -354,6 +356,10 @@ class Tool:
             if "x_opencti_granted_refs" not in stix_object:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
                 )
 
             return self.opencti.tool.create(
@@ -409,6 +415,11 @@ class Tool:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/entities/opencti_vulnerability.py
+++ b/pycti/entities/opencti_vulnerability.py
@@ -294,6 +294,7 @@ class Vulnerability:
         )
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
+        x_opencti_workflow_id = kwargs.get("x_opencti_workflow_id", None)
         update = kwargs.get("update", False)
 
         if name is not None:
@@ -333,6 +334,7 @@ class Vulnerability:
                         "x_opencti_cvss_availability_impact": x_opencti_cvss_availability_impact,
                         "x_opencti_cvss_confidentiality_impact": x_opencti_cvss_confidentiality_impact,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
+                        "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
                     }
                 },
@@ -431,6 +433,10 @@ class Vulnerability:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_workflow_id" not in stix_object:
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
             return self.create(
                 stix_id=stix_object["id"],
                 createdBy=(
@@ -505,6 +511,11 @@ class Vulnerability:
                 objectOrganization=(
                     stix_object["x_opencti_granted_refs"]
                     if "x_opencti_granted_refs" in stix_object
+                    else None
+                ),
+                x_opencti_workflow_id=(
+                    stix_object["x_opencti_workflow_id"]
+                    if "x_opencti_workflow_id" in stix_object
                     else None
                 ),
                 update=update,

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1396,6 +1396,11 @@ class OpenCTIStix2:
             objectOrganization=(
                 extras["granted_refs_ids"] if "granted_refs_ids" in extras else []
             ),
+            x_opencti_workflow_id=(
+                stix_sighting["x_opencti_workflow_id"]
+                if "x_opencti_workflow_id" in stix_sighting
+                else None
+            ),
             update=update,
             ignore_dates=(
                 stix_sighting["x_opencti_ignore_dates"]

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1355,6 +1355,10 @@ class OpenCTIStix2:
             stix_sighting["x_opencti_negative"] = (
                 self.opencti.get_attribute_in_extension("negative", stix_sighting)
             )
+        if "x_opencti_workflow_id" not in stix_sighting:
+            stix_sighting["x_opencti_workflow_id"] = (
+                self.opencti.get_attribute_in_extension("workflow_id", stix_sighting)
+            )
         stix_sighting_result = self.opencti.stix_sighting_relationship.create(
             fromId=final_from_id,
             toId=final_to_id,


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

add status x_opencti_workflow_id for entities and relationships:
*  `relationship` `grouping` `note` `case RFT` `case RFI`  `feedback` `observedData`  `campaign`  `tool` `vulnerability`
* `attackPattern` `narrative` `course of action` `dataComponent` `dataSource` `Region` `Area` `Country` `City` `Position` `Malware` `Infrastructure`  `sighting`   `Indicator` 

was already ok for:
* `Report`  `Malware Analysis`  `IR` `Incident`  `Channel` `Indicator`

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/7114
*  opencti PR: https://github.com/OpenCTI-Platform/opencti/pull/7408


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
