### PR TITLE
WithFiles was not requested when full export of report (#686)

### DIFF
--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -504,7 +504,8 @@ class Report:
             first = 100
 
         self.opencti.app_logger.info(
-            "Listing Reports with filters", {"filters": json.dumps(filters)}
+            "Listing Reports with filters",
+            {"filters": json.dumps(filters), "with_files:": with_files},
         )
         query = (
             """
@@ -604,7 +605,7 @@ class Report:
             result = self.opencti.query(query, {"id": id})
             return self.opencti.process_multiple_fields(result["data"]["report"])
         elif filters is not None:
-            result = self.list(filters=filters)
+            result = self.list(filters=filters, withFiles=with_files)
             if len(result) > 0:
                 return result[0]
             else:

--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -583,7 +583,9 @@ class Report:
         custom_attributes = kwargs.get("customAttributes", None)
         with_files = kwargs.get("withFiles", False)
         if id is not None:
-            self.opencti.app_logger.info("Reading Report", {"id": id, "with_files": with_files})
+            self.opencti.app_logger.info(
+                "Reading Report", {"id": id, "with_files": with_files}
+            )
             query = (
                 """
                 query Report($id: String!) {

--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -583,7 +583,7 @@ class Report:
         custom_attributes = kwargs.get("customAttributes", None)
         with_files = kwargs.get("withFiles", False)
         if id is not None:
-            self.opencti.app_logger.info("Reading Report", {"id": id})
+            self.opencti.app_logger.info("Reading Report", {"id": id, "with_files": with_files})
             query = (
                 """
                 query Report($id: String!) {

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2237,6 +2237,7 @@ class OpenCTIStix2:
         orderBy: str = None,
         orderMode: str = None,
         getAll: bool = True,
+        withFiles: bool = False,
     ) -> [Dict]:
         if IdentityTypes.has_value(entity_type):
             entity_type = "Identity"
@@ -2300,6 +2301,7 @@ class OpenCTIStix2:
             orderBy=orderBy,
             orderMode=orderMode,
             getAll=getAll,
+            withFiles=withFiles,
         )
 
     def export_list(
@@ -2334,6 +2336,7 @@ class OpenCTIStix2:
             orderBy=order_by,
             orderMode=order_mode,
             getAll=True,
+            withFiles=(mode == "full"),
         )
         if entities_list is not None:
             uuids = []

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2188,7 +2188,7 @@ class OpenCTIStix2:
             "objects": [],
         }
         do_read = self.get_reader(entity_type)
-        entity = do_read(id=entity_id)
+        entity = do_read(id=entity_id, withFiles=(mode == "full"))
         if entity is None:
             self.opencti.app_logger.error(
                 "Cannot export entity (not found)", {"id": entity_id}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add the "WithFiles" args to True when export mode equals "full" for both report list and report alone export.

Tested locally: full export of a report has now the attach file in exported json, simple export of report does not have the attach file on json.

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/686

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
