### PR TITLE
[client] Ensure the valid_until date on Indicators is set to a greater value than valid_from when empty

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,7 +1507,9 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            entity['valid_until'] = entity['valid_until'] + datetime.timedelta(seconds=1)
+            entity["valid_until"] = entity["valid_until"] + datetime.timedelta(
+                seconds=1
+            )
 
         # Flatten
         if "tasks" in entity:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,7 +1507,7 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            entity["valid_until"] = entity["valid_until"] + datetime.timedelta(
+            entity["valid_until"] = entity["valid_from"] + datetime.timedelta(
                 seconds=1
             )
 

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,9 +1507,7 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            entity["valid_until"] = entity["valid_from"] + datetime.timedelta(
-                seconds=1
-            )
+            entity["valid_until"] = entity["valid_from"] + datetime.timedelta(seconds=1)
 
         # Flatten
         if "tasks" in entity:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,7 +1507,7 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            del entity["valid_from"]
+            entity['valid_until'] = entity['valid_until'] + datetime.timedelta(seconds=1)
 
         # Flatten
         if "tasks" in entity:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,7 +1507,7 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            valid_until_converted_datetime = datetime.strptime(
+            valid_until_converted_datetime = datetime.datetime.strptime(
                 entity["valid_until"], "%Y-%m-%dT%H:%M:%S.%fZ"
             )
             new_valid_until = valid_until_converted_datetime + datetime.timedelta(

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -1507,7 +1507,16 @@ class OpenCTIStix2:
             and "valid_until" in entity
             and entity["valid_from"] == entity["valid_until"]
         ):
-            entity["valid_until"] = entity["valid_from"] + datetime.timedelta(seconds=1)
+            valid_until_converted_datetime = datetime.strptime(
+                entity["valid_until"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            new_valid_until = valid_until_converted_datetime + datetime.timedelta(
+                seconds=1
+            )
+            valid_until_converted_string = new_valid_until.strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            entity["valid_until"] = valid_until_converted_string
 
         # Flatten
         if "tasks" in entity:


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Add one seconde to the valid_until date if valid_from equals valid_until

### Related issues

* https://github.com/OpenCTI-Platform/opencti/pull/7227
* https://github.com/OpenCTI-Platform/connectors/issues/2182
* https://github.com/OpenCTI-Platform/client-python/issues/692 [client]

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
