### PR TITLE
[client-python] Remove external reference from mapping cache

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -536,8 +536,6 @@ class OpenCTIStix2:
                     )
                     if generated_ref_id is None:
                         continue
-                    if generated_ref_id in self.mapping_cache:
-                        external_reference_id = self.mapping_cache[generated_ref_id]
                     else:
                         external_reference_id = self.opencti.external_reference.create(
                             source_name=source_name,
@@ -582,7 +580,6 @@ class OpenCTIStix2:
                                         "no_trigger_import", False
                                     ),
                                 )
-                    self.mapping_cache[generated_ref_id] = generated_ref_id
                     external_references_ids.append(external_reference_id)
                     if stix_object["type"] in [
                         "threat-actor",
@@ -713,8 +710,6 @@ class OpenCTIStix2:
                 )
                 if generated_ref_id is None:
                     continue
-                if generated_ref_id in self.mapping_cache:
-                    external_reference_id = self.mapping_cache[generated_ref_id]
                 else:
                     external_reference_id = self.opencti.external_reference.create(
                         source_name=source_name,
@@ -753,7 +748,6 @@ class OpenCTIStix2:
                                 mime_type=file["mime_type"],
                                 no_trigger_import=file.get("no_trigger_import", False),
                             )
-                self.mapping_cache[generated_ref_id] = generated_ref_id
                 external_references_ids.append(external_reference_id)
         # Granted refs
         granted_refs_ids = []


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*  Remove external reference from mapping cache

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/7217

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
