### PR TITLE
[client-python] get all report's properties when using csv mapper (#6947)

### DIFF
--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -896,7 +896,9 @@ class Report:
                 )
             if "x_opencti_participant_ids" not in stix_object:
                 stix_object["x_opencti_participant_ids"] = (
-                    self.opencti.get_attribute_in_extension("participant_ids", stix_object)
+                    self.opencti.get_attribute_in_extension(
+                        "participant_ids", stix_object
+                    )
                 )
             return self.create(
                 stix_id=stix_object["id"],

--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -694,6 +694,8 @@ class Report:
         created_by = kwargs.get("createdBy", None)
         objects = kwargs.get("objects", None)
         object_marking = kwargs.get("objectMarking", None)
+        object_assignee = kwargs.get("objectAssignee", None)
+        object_participant = kwargs.get("objectParticipant", None)
         object_label = kwargs.get("objectLabel", None)
         external_references = kwargs.get("externalReferences", None)
         revoked = kwargs.get("revoked", None)
@@ -733,6 +735,8 @@ class Report:
                         "objectMarking": object_marking,
                         "objectLabel": object_label,
                         "objectOrganization": granted_refs,
+                        "objectAssignee": object_assignee,
+                        "objectParticipant": object_participant,
                         "objects": objects,
                         "externalReferences": external_references,
                         "revoked": revoked,
@@ -886,7 +890,14 @@ class Report:
                 )
             if "x_opencti_content" in stix_object:
                 stix_object["content"] = stix_object["x_opencti_content"]
-
+            if "x_opencti_assignee_ids" not in stix_object:
+                stix_object["x_opencti_assignee_ids"] = (
+                    self.opencti.get_attribute_in_extension("assignee_ids", stix_object)
+                )
+            if "x_opencti_participant_ids" not in stix_object:
+                stix_object["x_opencti_participant_ids"] = (
+                    self.opencti.get_attribute_in_extension("participant_ids", stix_object)
+                )
             return self.create(
                 stix_id=stix_object["id"],
                 createdBy=(
@@ -895,6 +906,16 @@ class Report:
                 objectMarking=(
                     extras["object_marking_ids"]
                     if "object_marking_ids" in extras
+                    else None
+                ),
+                objectAssignee=(
+                    stix_object["x_opencti_assignee_ids"]
+                    if "x_opencti_assignee_ids" in stix_object
+                    else None
+                ),
+                objectParticipant=(
+                    stix_object["x_opencti_participant_ids"]
+                    if "x_opencti_participant_ids" in stix_object
                     else None
                 ),
                 objectLabel=(


### PR DESCRIPTION
### Proposed changes

- add 2 properties into a report : participant & assignee

### Related issues

- [#6947](https://github.com/OpenCTI-Platform/opencti/issues/6947)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

multi repository : Opencti https://github.com/OpenCTI-Platform/opencti/pull/7824
