### PR TITLE
[client-python] missing mandatory input in Case Rfi/Rft queries (#725)

### DIFF
--- a/pycti/entities/opencti_case_rfi.py
+++ b/pycti/entities/opencti_case_rfi.py
@@ -747,7 +747,7 @@ class CaseRfi:
                 },
             )
             query = """
-               mutation CaseRfiEditRelationAdd($id: ID!, $input: StixRefRelationshipAddInput) {
+               mutation CaseRfiEditRelationAdd($id: ID!, $input: StixRefRelationshipAddInput!) {
                    stixDomainObjectEdit(id: $id) {
                         relationAdd(input: $input) {
                             id

--- a/pycti/entities/opencti_case_rft.py
+++ b/pycti/entities/opencti_case_rft.py
@@ -746,7 +746,7 @@ class CaseRft:
                 },
             )
             query = """
-               mutation CaseRftEditRelationAdd($id: ID!, $input: StixRefRelationshipAddInput) {
+               mutation CaseRftEditRelationAdd($id: ID!, $input: StixRefRelationshipAddInput!) {
                    stixDomainObjectEdit(id: $id) {
                         relationAdd(input: $input) {
                             id


### PR DESCRIPTION
### Proposed changes
make input mandatory in two queries where the '!' was missing

### Related issues
https://github.com/OpenCTI-Platform/client-python/issues/725
