### PR TITLE
[client] prevent export list from ordering by _score

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2280,6 +2280,10 @@ class OpenCTIStix2:
         do_list = lister.get(
             entity_type, lambda **kwargs: self.unknown_type({"type": entity_type})
         )
+
+        if getAll and (orderBy is None or orderBy == "_score"):
+            orderBy = "created_at"
+
         # noinspection PyTypeChecker
         return do_list(
             search=search,

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2283,6 +2283,8 @@ class OpenCTIStix2:
 
         if getAll and (orderBy is None or orderBy == "_score"):
             orderBy = "created_at"
+            if orderMode is None:
+                orderMode = "desc"
 
         # noinspection PyTypeChecker
         return do_list(


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* to prevent pagination issue, we prevent paginition ordering by _score during export

### Related issues

* opencti #8421

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
