### PR TITLE
Allow from_or_to_id to get relationship

### DIFF
--- a/pycti/entities/opencti_stix_core_relationship.py
+++ b/pycti/entities/opencti_stix_core_relationship.py
@@ -553,7 +553,7 @@ class StixCoreRelationship:
                 return result[0]
             else:
                 return None
-        elif from_id is not None and to_id is not None:
+        elif from_or_to_id is not None or (from_id is not None and to_id is not None):
             result = self.list(
                 fromOrToId=from_or_to_id,
                 fromId=from_id,


### PR DESCRIPTION
### Proposed changes

* Allow read relationship using from_or_to_id

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

I guess it's a programming oversight not to allow read using from_or_to_id since it works just by adding this condition.
I'm open to adding a test case for this change but I wasn't able to find a proper example with fixtures.

### How to test

* Get the id of an element with a relationship from your OpenCTI

```py
import pycti

OPENCTI_URL = "http://localhost:8080"
OPENCTI_TOKEN = "<token>"
opencti_client = pycti.OpenCTIApiClient(OPENCTI_URL, OPENCTI_TOKEN)
toto = opencti_client.stix_core_relationship.read(
    fromOrToId="<id of an element with a relationship>"
)
print(toto)
```