### PR TITLE
Fix OpenCTIApiClient parameter types

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -83,13 +83,13 @@ class OpenCTIApiClient:
     :param log_level: log level for the client
     :type log_level: str, optional
     :param ssl_verify: Requiring the requests to verify the TLS certificate at the server.
-    :type ssl_verify: bool, optional
+    :type ssl_verify: bool, str, optional
     :param proxies:
     :type proxies: dict, optional, The proxy configuration, would have `http` and `https` attributes. Defaults to {}
         ```
         proxies: {
-            "http: "http://my_proxy:8080"
-            "https: "http://my_proxy:8080"
+            "http": "http://my_proxy:8080"
+            "https": "http://my_proxy:8080"
         }
         ```
     :param json_logging: format the logs as json if set to True
@@ -102,14 +102,14 @@ class OpenCTIApiClient:
 
     def __init__(
         self,
-        url,
-        token,
+        url: str,
+        token: str,
         log_level="info",
-        ssl_verify=False,
-        proxies=None,
+        ssl_verify: bool | str = False,
+        proxies: dict[str,str] | None = None,
         json_logging=False,
         bundle_send_to_queue=True,
-        cert=None,
+        cert: str | tuple[str, str] |None = None,
         auth=None,
         perform_health_check=True,
     ):


### PR DESCRIPTION
### Proposed changes

The `OpenCTIApiClient` class constructor has some parameters that are internally passed to the Python `requests` libraries functions. `ssl_verify` is passed to the `verify` parameter of request of `self.session.get` and `self.session.post`. This PR corrects the type hint for `ssl_verify` - previously it was `bool`, however it can also be a `str` (["path to a CA_BUNDLE file or directory with certificates of trusted CAs"](https://requests.readthedocs.io/en/latest/user/advanced/#:~:text=path%20to%20a%20CA_BUNDLE%20file%20or%20directory%20with%20certificates%20of%20trusted%20CAs)). It also provides type hints for the other untyped parameters.


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case - it's just a type hint, don't know if a test is relevant
- [x] I added/update the relevant documentation (either on github or on notion) - edited the inline doc string
- [x] Where necessary I refactored code to improve the overall quality

