### PR TITLE
Implement log shipping to Graylog via GELF

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -98,6 +98,18 @@ class OpenCTIApiClient:
     :type cert: str, tuple, optional
     :param auth: Add a AuthBase class with custom authentication for you OpenCTI infrastructure.
     :type auth: requests.auth.AuthBase, optional
+    :param graylog_host: Graylog host name or IP address
+    :type graylog_host: str, optional
+    :param graylog_port: Graylog port
+    :type graylog_port: int, optional
+    :param graylog_adapter: the Graylog adapter to use. Valid values are "udp" and "tcp". Uses UDP by default.
+    :type graylog_adapter: str, optional
+    :param log_shipping_level: log level when shipping logs remotely
+    :type log_shipping_level: str, optional
+    :param log_shipping_env_var_prefix: The prefix used to match environment variables. Matching variables will be added
+        as meta info to the log data. The value of this property will be stripped from the name of the environment
+        variable.
+    :type log_shipping_env_var_prefix: str, optional
     """
 
     def __init__(
@@ -112,6 +124,11 @@ class OpenCTIApiClient:
         cert=None,
         auth=None,
         perform_health_check=True,
+        graylog_host=None,
+        graylog_port=None,
+        graylog_adapter=None,
+        log_shipping_level=None,
+        log_shipping_env_var_prefix=None,
     ):
         """Constructor method"""
 
@@ -126,7 +143,9 @@ class OpenCTIApiClient:
             raise ValueError("A TOKEN must be set")
 
         # Configure logger
-        self.logger_class = logger(log_level.upper(), json_logging)
+        self.logger_class = logger(log_level.upper(), json_logging, graylog_host, graylog_port, graylog_adapter,
+                                   log_shipping_level.upper() if log_shipping_level is not None else None,
+                                   log_shipping_env_var_prefix)
         self.app_logger = self.logger_class("api")
 
         # Define API

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -878,6 +878,21 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         self.log_level = get_config_variable(
             "CONNECTOR_LOG_LEVEL", ["connector", "log_level"], config, default="INFO"
         ).upper()
+        self.graylog_host = get_config_variable(
+            "CONNECTOR_GRAYLOG_HOST", ["connector", "graylog_host"], config
+        )
+        self.graylog_port = get_config_variable(
+            "CONNECTOR_GRAYLOG_PORT", ["connector", "graylog_port"], config, True, 12201
+        )
+        self.graylog_adapter = get_config_variable(
+            "CONNECTOR_GRAYLOG_ADAPTER", ["connector", "graylog_adapter"], config, default="udp"
+        )
+        self.log_shipping_level = get_config_variable(
+            "CONNECTOR_LOG_SHIPPING_LEVEL", ["connector", "log_shipping_level"], config, default="INFO"
+        ).upper()
+        self.log_shipping_env_var_prefix = get_config_variable(
+            "CONNECTOR_LOG_SHIPPING_ENV_VAR_PREFIX", ["connector", "log_shipping_env_var_prefix"], config
+        )
         self.connect_run_and_terminate = get_config_variable(
             "CONNECTOR_RUN_AND_TERMINATE",
             ["connector", "run_and_terminate"],
@@ -915,6 +930,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.opencti_ssl_verify,
             json_logging=self.opencti_json_logging,
             bundle_send_to_queue=self.bundle_send_to_queue,
+            graylog_host=self.graylog_host,
+            graylog_port=self.graylog_port,
+            graylog_adapter=self.graylog_adapter,
+            log_shipping_level=self.log_shipping_level,
+            log_shipping_env_var_prefix=self.log_shipping_env_var_prefix,
         )
         # - Impersonate API that will use applicant id
         # Behave like standard api if applicant not found
@@ -925,6 +945,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.opencti_ssl_verify,
             json_logging=self.opencti_json_logging,
             bundle_send_to_queue=self.bundle_send_to_queue,
+            graylog_host=self.graylog_host,
+            graylog_port=self.graylog_port,
+            graylog_adapter=self.graylog_adapter,
+            log_shipping_level=self.log_shipping_level,
+            log_shipping_env_var_prefix=self.log_shipping_env_var_prefix,
         )
         self.connector_logger = self.api.logger_class(self.connect_name)
         # For retro compatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ deprecation~=2.1.0
 # OpenCTI
 filigran-sseclient~=1.0.0
 stix2~=3.0.1
+pygelf~=0.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     # OpenCTI
     filigran-sseclient~=1.0.0
     stix2~=3.0.1
+    pygelf~=0.4.2
 
 [options.extras_require]
 dev =

--- a/tests/cases/connectors.py
+++ b/tests/cases/connectors.py
@@ -63,6 +63,7 @@ class ExternalImportConnector:
         os.environ["OPENCTI_JSON_LOGGING"] = "true"
         os.environ["CONNECTOR_EXPOSE_METRICS"] = "true"
         os.environ["CONNECTOR_METRICS_PORT"] = "9096"
+        os.environ["GRAYLOG_DUMMY_VAR"] = "dummy_value"
 
         config = (
             yaml.load(open(config_file_path), Loader=yaml.FullLoader)

--- a/tests/data/external_import_config.yml
+++ b/tests/data/external_import_config.yml
@@ -6,6 +6,11 @@ connector:
   confidence_level: 80 # From 0 (Unknown) to 100 (Fully trusted)
   update_existing_data: True
   log_level: 'debug'
+  graylog_host: '127.0.0.1'
+  graylog_port: 12201
+  graylog_adapter: 'tcp'
+  log_shipping_level: 'warn'
+  log_shipping_env_var_prefix: 'GRAYLOG_'
 
 test:
   interval: 1

--- a/tests/data/internal_import_config.yml
+++ b/tests/data/internal_import_config.yml
@@ -7,3 +7,4 @@ connector:
   only_contextual: true # Only extract data related to an entity (a report, a threat actor, etc.)
   confidence_level: 15 # From 0 (Unknown) to 100 (Fully trusted)
   log_level: 'debug'
+  graylog_host: '127.0.0.1'


### PR DESCRIPTION
### Proposed changes

* Shipping of logs to Graylog via GELF

### Related issues

There are no related issues but this subject has been previously discussed with Linkare within the scope of the OpenCTI implementation for the CCB (https://ccb.belgium.be/).

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

We enabled the new functionality in the configuration of some of the existing test cases. However, there are currently no new assertions being made as that would require the set-up of an entire Graylog infrastructure during tests, which is a much more involved task. Effectively, this means that the new code is being exercised but all log shipping is being shipped to a closed port and any network errors are silently ignored.