### PR TITLE
Remove harcoded first value when getting all indicators

### DIFF
--- a/pycti/entities/opencti_indicator.py
+++ b/pycti/entities/opencti_indicator.py
@@ -63,8 +63,6 @@ class Indicator:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Indicators with filters", {"filters": json.dumps(filters)}
@@ -366,13 +364,13 @@ class Indicator:
         if stix_object is not None:
             # Search in extensions
             if "x_opencti_score" not in stix_object:
-                stix_object["x_opencti_score"] = (
-                    self.opencti.get_attribute_in_extension("score", stix_object)
-                )
+                stix_object[
+                    "x_opencti_score"
+                ] = self.opencti.get_attribute_in_extension("score", stix_object)
             if "x_opencti_detection" not in stix_object:
-                stix_object["x_opencti_detection"] = (
-                    self.opencti.get_attribute_in_extension("detection", stix_object)
-                )
+                stix_object[
+                    "x_opencti_detection"
+                ] = self.opencti.get_attribute_in_extension("detection", stix_object)
             if (
                 "x_opencti_main_observable_type" not in stix_object
                 and self.opencti.get_attribute_in_extension(
@@ -380,29 +378,29 @@ class Indicator:
                 )
                 is not None
             ):
-                stix_object["x_opencti_main_observable_type"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "main_observable_type", stix_object
-                    )
+                stix_object[
+                    "x_opencti_main_observable_type"
+                ] = self.opencti.get_attribute_in_extension(
+                    "main_observable_type", stix_object
                 )
             if "x_opencti_create_observables" not in stix_object:
-                stix_object["x_opencti_create_observables"] = (
-                    self.opencti.get_attribute_in_extension(
-                        "create_observables", stix_object
-                    )
+                stix_object[
+                    "x_opencti_create_observables"
+                ] = self.opencti.get_attribute_in_extension(
+                    "create_observables", stix_object
                 )
             if "x_opencti_stix_ids" not in stix_object:
-                stix_object["x_opencti_stix_ids"] = (
-                    self.opencti.get_attribute_in_extension("stix_ids", stix_object)
-                )
+                stix_object[
+                    "x_opencti_stix_ids"
+                ] = self.opencti.get_attribute_in_extension("stix_ids", stix_object)
             if "x_opencti_granted_refs" not in stix_object:
-                stix_object["x_opencti_granted_refs"] = (
-                    self.opencti.get_attribute_in_extension("granted_refs", stix_object)
-                )
+                stix_object[
+                    "x_opencti_granted_refs"
+                ] = self.opencti.get_attribute_in_extension("granted_refs", stix_object)
             if "x_opencti_workflow_id" not in stix_object:
-                stix_object["x_opencti_workflow_id"] = (
-                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
-                )
+                stix_object[
+                    "x_opencti_workflow_id"
+                ] = self.opencti.get_attribute_in_extension("workflow_id", stix_object)
 
             return self.create(
                 stix_id=stix_object["id"],

--- a/pycti/entities/opencti_indicator.py
+++ b/pycti/entities/opencti_indicator.py
@@ -364,13 +364,13 @@ class Indicator:
         if stix_object is not None:
             # Search in extensions
             if "x_opencti_score" not in stix_object:
-                stix_object[
-                    "x_opencti_score"
-                ] = self.opencti.get_attribute_in_extension("score", stix_object)
+                stix_object["x_opencti_score"] = (
+                    self.opencti.get_attribute_in_extension("score", stix_object)
+                )
             if "x_opencti_detection" not in stix_object:
-                stix_object[
-                    "x_opencti_detection"
-                ] = self.opencti.get_attribute_in_extension("detection", stix_object)
+                stix_object["x_opencti_detection"] = (
+                    self.opencti.get_attribute_in_extension("detection", stix_object)
+                )
             if (
                 "x_opencti_main_observable_type" not in stix_object
                 and self.opencti.get_attribute_in_extension(
@@ -378,29 +378,29 @@ class Indicator:
                 )
                 is not None
             ):
-                stix_object[
-                    "x_opencti_main_observable_type"
-                ] = self.opencti.get_attribute_in_extension(
-                    "main_observable_type", stix_object
+                stix_object["x_opencti_main_observable_type"] = (
+                    self.opencti.get_attribute_in_extension(
+                        "main_observable_type", stix_object
+                    )
                 )
             if "x_opencti_create_observables" not in stix_object:
-                stix_object[
-                    "x_opencti_create_observables"
-                ] = self.opencti.get_attribute_in_extension(
-                    "create_observables", stix_object
+                stix_object["x_opencti_create_observables"] = (
+                    self.opencti.get_attribute_in_extension(
+                        "create_observables", stix_object
+                    )
                 )
             if "x_opencti_stix_ids" not in stix_object:
-                stix_object[
-                    "x_opencti_stix_ids"
-                ] = self.opencti.get_attribute_in_extension("stix_ids", stix_object)
+                stix_object["x_opencti_stix_ids"] = (
+                    self.opencti.get_attribute_in_extension("stix_ids", stix_object)
+                )
             if "x_opencti_granted_refs" not in stix_object:
-                stix_object[
-                    "x_opencti_granted_refs"
-                ] = self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                stix_object["x_opencti_granted_refs"] = (
+                    self.opencti.get_attribute_in_extension("granted_refs", stix_object)
+                )
             if "x_opencti_workflow_id" not in stix_object:
-                stix_object[
-                    "x_opencti_workflow_id"
-                ] = self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                stix_object["x_opencti_workflow_id"] = (
+                    self.opencti.get_attribute_in_extension("workflow_id", stix_object)
+                )
 
             return self.create(
                 stix_id=stix_object["id"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* The page size listing all indicators with the "getAll" param was hardcoded to 100. To increase performance, this restriction is proposed to be removed.

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/457

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
