### PR TITLE
[CI] Add container build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
           name: Build opencti/python-cliente
           command: |
             docker run --privileged --rm tonistiigi/binfmt --install all
+            CIRCLE_TAG=${CIRCLE_TAG:-nightly}
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
             docker build -t opencti/client-python:${CIRCLE_TAG} .
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt --install all
             CIRCLE_TAG=${CIRCLE_TAG:-nightly}
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
-            BASE_REPO="renizmy"
+            BASE_REPO="opencti"
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
             docker buildx inspect mybuilder --bootstrap            
@@ -168,7 +168,7 @@ workflows:
       - build-container:
           filters:
             tags:
-              only: /.*/
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
       - build-library:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,16 +55,17 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build opencti/python-cliente
+          name: Build opencti/python-client
           command: |
             docker run --privileged --rm tonistiigi/binfmt --install all
             CIRCLE_TAG=${CIRCLE_TAG:-nightly}
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
-            docker build -t opencti/client-python:${CIRCLE_TAG} .
+            BASE_REPO="renizmy"
+            docker build -t $BASE_REPO/client-python:${CIRCLE_TAG} .
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            
-            docker tag opencti/client-python:${CIRCLE_TAG} opencti/client-python:latest
-            docker push opencti/client-python:${CIRCLE_TAG}
-            docker push opencti/client-python:latest
+            docker tag $BASE_REPO/client-python:${CIRCLE_TAG} $BASE_REPO/client-python:latest
+            docker push $BASE_REPO/client-python:${CIRCLE_TAG}
+            docker push $BASE_REPO/client-python:latest
   build-library:
     working_directory: ~/opencti-client
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           name: Build opencti/python-cliente
           command: |
             docker run --privileged --rm tonistiigi/binfmt --install all
-            docker build -t opencti/client-python:${CIRCLE_TAG}
+            docker build -t opencti/client-python:${CIRCLE_TAG} .
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            
             docker tag opencti/client-python:${CIRCLE_TAG} opencti/client-python:latest
             docker push opencti/client-python:${CIRCLE_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker buildx create --use --name mybuilder || true
             docker buildx inspect mybuilder --bootstrap            
-            docker buildx build \
+            docker buildx build . \
               --platform linux/amd64,linux/arm64 \
               -t $BASE_REPO/client-python:${CIRCLE_TAG} \
               -t $BASE_REPO/client-python:latest \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ orbs:
   slack: circleci/slack@4.13.3
   ms-teams: cloudradar-monitoring/ms-teams@0.0.1
 env:
-  BASE_REPO: opencti
+  DOCKER_REPO: opencti
+  GHCR_REPO: ghcr.io/OpenCTI-Platform/client-python
 jobs:
   ensure_formatting:
     docker:
@@ -50,55 +51,41 @@ jobs:
       - ms-teams/report:
           only_on_fail: true
           webhook_url: $MS_TEAMS_WEBHOOK_URL
-  build-container-python-3-11:
-    docker:
-      - image: cimg/base:stable-20.04
+
+  build-container:
+    executor: docker/docker
+    parameters:
+      python_version:
+        type: string
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
-          name: Build opencti/python-client-container
+          name: Setup Docker Buildx
           command: |
-            docker run --privileged --rm tonistiigi/binfmt --install all
-            CIRCLE_TAG=${CIRCLE_TAG:-nightly}
-            echo "CIRCLE_TAG=${CIRCLE_TAG}"
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
-            docker buildx inspect mybuilder --bootstrap            
-            docker buildx build . \
-              --platform linux/amd64,linux/arm64 \
-              -t ${{ env.BASE_REPO }}/client-python-3-11:${CIRCLE_TAG} \
-              -t ${{ env.BASE_REPO }}client-python-3-11:latest \
-              --build-arg BASE_IMAGE="python:3.11-alpine3.20" 
+            docker buildx create --driver docker-container --name multiarch --use
+      - run:
+          name: Login to Docker Hub
+          command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - run:
+          name: Login to GitHub Container Registry
+          command: echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_USERNAME" --password-stdin
 
       - run:
-          name: Push image to regsitry
-          command: docker push ${{ env.BASE_REPO }}/client-python-3-11:latest --all-tags
-
-  build-container-python-3-12:
-    docker:
-      - image: cimg/base:stable-20.04
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build opencti/python-client
+          name: Build and Push Alpine Multi-arch Image
           command: |
-            docker run --privileged --rm tonistiigi/binfmt --install all
-            CIRCLE_TAG=${CIRCLE_TAG:-nightly}
-            echo "CIRCLE_TAG=${CIRCLE_TAG}"
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
-            docker buildx inspect mybuilder --bootstrap
-            docker buildx build . \
+            VERSION=${CIRCLE_TAG:-latest}
+            PYTHON_VERSION_TAG=$(echo "<< parameters.python_version >>" | sed 's/\./-/g')
+            docker buildx build \
               --platform linux/amd64,linux/arm64 \
-              -t ${{ env.BASE_REPO }}/client-python-3-12:${CIRCLE_TAG} \
-              -t ${{ env.BASE_REPO }}/client-python-3-12:latest \
-              --build-arg BASE_IMAGE="python:3.12-alpine3.20" 
-
-      - run:
-          name: Push image to regsitry
-          command: docker push ${{ env.BASE_REPO }}/client-python-3-12:latest --all-tags
+              --file Dockerfile.alpine \
+              --tag ${{ env.DOCKER_REPO }}/client-python-${PYTHON_VERSION_TAG}:${VERSION} \
+              --tag ${{ env.DOCKER_REPO }}/client-python-${PYTHON_VERSION_TAG}:latest \
+              --tag ${{ env.GHCR_REPO }}/client-python-${PYTHON_VERSION_TAG}:${VERSION} \
+              --tag ${{ env.GHCR_REPO }}/client-python-${PYTHON_VERSION_TAG}:latest \
+              --push \
+              --file Dockerfile
 
   build-library:
     working_directory: ~/opencti-client
@@ -196,18 +183,17 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-container-python-3-11:
+
+      - build-container:
+          matrix:
+            parameters:
+              python_version: ["3.11", "3.12"]
           requires:
             - build-library
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
-      - build-container-python-3-12:
-          requires:
-            - build-library
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
+
       - build-library:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,14 @@ jobs:
             CIRCLE_TAG=${CIRCLE_TAG:-nightly}
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
             BASE_REPO="renizmy"
-            docker build -t $BASE_REPO/client-python:${CIRCLE_TAG} .
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            
-            docker tag $BASE_REPO/client-python:${CIRCLE_TAG} $BASE_REPO/client-python:latest
-            docker push $BASE_REPO/client-python:${CIRCLE_TAG}
-            docker push $BASE_REPO/client-python:latest
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker buildx create --use --name mybuilder || true
+            docker buildx inspect mybuilder --bootstrap            
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              -t $BASE_REPO/client-python:${CIRCLE_TAG} \
+              -t $BASE_REPO/client-python:latest \
+              --push
   build-library:
     working_directory: ~/opencti-client
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,17 +69,7 @@ jobs:
               --platform linux/amd64,linux/arm64 \
               -t ${{ env.BASE_REPO }}/client-python-3-11:${CIRCLE_TAG} \
               -t ${{ env.BASE_REPO }}client-python-3-11:latest \
-              --build-arg BASE_IMAGE="python:3.11-alpine3.20" \
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ${{ env.BASE_REPO }}/client-python-3-11:latest
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+              --build-arg BASE_IMAGE="python:3.11-alpine3.20" 
 
       - run:
           name: Push image to regsitry
@@ -104,17 +94,7 @@ jobs:
               --platform linux/amd64,linux/arm64 \
               -t ${{ env.BASE_REPO }}/client-python-3-12:${CIRCLE_TAG} \
               -t ${{ env.BASE_REPO }}/client-python-3-12:latest \
-              --build-arg BASE_IMAGE="python:3.12-alpine3.20" \
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: ${{ env.BASE_REPO }}/client-python-3-11:latest
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+              --build-arg BASE_IMAGE="python:3.12-alpine3.20" 
 
       - run:
           name: Push image to regsitry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,7 @@ jobs:
           name: Build opencti/python-cliente
           command: |
             docker run --privileged --rm tonistiigi/binfmt --install all
+            echo "CIRCLE_TAG=${CIRCLE_TAG}"
             docker build -t opencti/client-python:${CIRCLE_TAG} .
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            
             docker tag opencti/client-python:${CIRCLE_TAG} opencti/client-python:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.1
 orbs:
   slack: circleci/slack@4.13.3
   ms-teams: cloudradar-monitoring/ms-teams@0.0.1
+env:
+  BASE_REPO: opencti
 jobs:
   ensure_formatting:
     docker:
@@ -48,7 +50,42 @@ jobs:
       - ms-teams/report:
           only_on_fail: true
           webhook_url: $MS_TEAMS_WEBHOOK_URL
-  build-container:
+  build-container-python-3-11:
+    docker:
+      - image: cimg/base:stable-20.04
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build opencti/python-client-container
+          command: |
+            docker run --privileged --rm tonistiigi/binfmt --install all
+            CIRCLE_TAG=${CIRCLE_TAG:-nightly}
+            echo "CIRCLE_TAG=${CIRCLE_TAG}"
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
+            docker buildx inspect mybuilder --bootstrap            
+            docker buildx build . \
+              --platform linux/amd64,linux/arm64 \
+              -t ${{ env.BASE_REPO }}/client-python-3-11:${CIRCLE_TAG} \
+              -t ${{ env.BASE_REPO }}client-python-3-11:latest \
+              --build-arg BASE_IMAGE="python:3.11-alpine3.20" \
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.BASE_REPO }}/client-python-3-11:latest
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - run:
+          name: Push image to regsitry
+          command: docker push ${{ env.BASE_REPO }}/client-python-3-11:latest --all-tags
+
+  build-container-python-3-12:
     docker:
       - image: cimg/base:stable-20.04
     steps:
@@ -60,15 +97,29 @@ jobs:
             docker run --privileged --rm tonistiigi/binfmt --install all
             CIRCLE_TAG=${CIRCLE_TAG:-nightly}
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
-            BASE_REPO="opencti"
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
-            docker buildx inspect mybuilder --bootstrap            
+            docker buildx inspect mybuilder --bootstrap
             docker buildx build . \
               --platform linux/amd64,linux/arm64 \
-              -t $BASE_REPO/client-python:${CIRCLE_TAG} \
-              -t $BASE_REPO/client-python:latest \
-              --push
+              -t ${{ env.BASE_REPO }}/client-python-3-12:${CIRCLE_TAG} \
+              -t ${{ env.BASE_REPO }}/client-python-3-12:latest \
+              --build-arg BASE_IMAGE="python:3.12-alpine3.20" \
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.BASE_REPO }}/client-python-3-11:latest
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - run:
+          name: Push image to regsitry
+          command: docker push ${{ env.BASE_REPO }}/client-python-3-12:latest --all-tags
+
   build-library:
     working_directory: ~/opencti-client
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ workflows:
       - build-container:
           filters:
             tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
+              only: /.*/
             branches:
               ignore: /.*/
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build opencti/python-client
+          name: Build opencti/python-cliente
           command: |
             docker run --privileged --rm tonistiigi/binfmt --install all
             docker build -t opencti/client-python:${CIRCLE_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,16 +159,14 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-library:
-          filters:
-            tags:
-              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
-            branches:
-              ignore: /.*/
       - build-container:
           filters:
             tags:
               only: /.*/
+      - build-library:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
             branches:
               ignore: /.*/
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
             echo "CIRCLE_TAG=${CIRCLE_TAG}"
             BASE_REPO="renizmy"
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker buildx create --use --name mybuilder || true
+            docker buildx create --platform linux/amd64,linux/arm64 --use --name mybuilder || true
             docker buildx inspect mybuilder --bootstrap            
             docker buildx build . \
               --platform linux/amd64,linux/arm64 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,10 +197,14 @@ workflows:
             tags:
               only: /.*/
       - build-container-python-3-11:
+          requires:
+            - build-library
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
       - build-container-python-3-12:
+          requires:
+            - build-library
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,9 +171,6 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-          requires:
-            - ensure_formatting
-            - linter
       - deploy:
           requires:
             - build-library

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,22 @@ jobs:
       - ms-teams/report:
           only_on_fail: true
           webhook_url: $MS_TEAMS_WEBHOOK_URL
-  build:
+  build-container:
+    docker:
+      - image: cimg/base:stable-20.04
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build opencti/python-client
+          command: |
+            docker run --privileged --rm tonistiigi/binfmt --install all
+            docker build -t opencti/client-python:${CIRCLE_TAG}
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin            
+            docker tag opencti/client-python:${CIRCLE_TAG} opencti/client-python:latest
+            docker push opencti/client-python:${CIRCLE_TAG}
+            docker push opencti/client-python:latest
+  build-library:
     working_directory: ~/opencti-client
     docker:
       - image: cimg/python:3.12
@@ -144,7 +159,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build:
+      - build-library:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
+            branches:
+              ignore: /.*/
+      - build-container:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
@@ -155,7 +176,7 @@ workflows:
             - linter
       - deploy:
           requires:
-            - build
+            - build-library
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
@@ -163,7 +184,7 @@ workflows:
               ignore: /.*/
       - notify_rolling:
           requires:
-            - build
+            - build-library
       - notify:
           requires:
             - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,11 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-container:
+      - build-container-python-3-11:
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/
+      - build-container-python-3-12:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)+(\.[0-9]+)?\.?(\w)*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ ARG BASE_IMAGE="python:3.12-alpine3.20"
 FROM ${BASE_IMAGE}
 
 # Install Python modules
-# hadolint ignore=DL3003
 COPY ./requirements.txt /opt/requirements.txt
 
 RUN apk --no-cache add git build-base libmagic libffi-dev && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,6 @@ COPY ./requirements.txt /opt/requirements.txt
 RUN apk --no-cache add git build-base libmagic libffi-dev && \
     pip3 install --no-cache-dir -r /opt/requirements.txt && \
     apk del git build-base && rm /opt/requirements.txt
+
+RUN adduser -D -g '' app
+USER app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE="python:3.12-alpine3.20"
+FROM ${BASE_IMAGE}
+
+# Install Python modules
+# hadolint ignore=DL3003
+COPY ./requirements.txt /opt/requirements.txt
+
+RUN apk --no-cache add git build-base libmagic libffi-dev && \
+    pip3 install --no-cache-dir -r /opt/requirements.txt && \
+    apk del git build-base && rm /opt/requirements.txt


### PR DESCRIPTION
# Create a Connector Base Image  ~~(WIP🚧)~~

- Should follow the same lifecycle as the Python library.
- ARM support has been implemented.

## Required environment variables for docker registry connection
- `DOCKERHUB_PASS`
- `DOCKERHUB_USERNAME`

## Completed Tasks
- [x] Python 3.12 build
- [x] Python 3.11 build
- [x] ARM image support
- [x] Use a dedicated app user instead of the default image user

## Pending Tasks
- [ ] Sign images
- [ ] Add solution to manually trigger nightly builds => Aborted
- [ ] Implement vulnerability scanner (with cache optimization)
