### PR TITLE
[client] handle new patch operation in bundle import (opencti #6728)

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2407,36 +2407,18 @@ class OpenCTIStix2:
 
         return bundle
 
-    def build_patch_input(
-        self,
-        raw_field_patch
-    ):
+    def get_patch_input(self, raw_field_patch):
         parsed_patch = json.loads(raw_field_patch)
-        full_input = []
-        for key in parsed_patch:
-            value = parsed_patch[key]
-            if len(value['replacedValue']) > 0:
-                replace_input = {'key': key, 'value': value['replacedValue'], 'operation': 'replace'}
-                full_input.append(replace_input)
-            else:
-                if len(value['addedValue']) > 0:
-                    add_input = {'key': key, 'value': value['addedValue'], 'operation': 'add'}
-                    full_input.append(add_input)
-                if len(value['removedValue']) > 0:
-                    add_input = {'key': key, 'value': value['removedValue'], 'operation': 'remove'}
-                    full_input.append(add_input)
+        return parsed_patch
 
-        return full_input
-
-    def apply_patch(
-        self,
-        item
-    ):
-        input = self.build_patch_input(item["opencti_field_patch"])
+    def apply_patch(self, item):
+        input = self.get_patch_input(item["opencti_field_patch"])
         if item["type"] == "relationship":
             self.opencti.stix_core_relationship.update_field(id=item["id"], input=input)
         elif item["type"] == "sighting":
-            self.opencti.stix_sighting_relationship.update_field(id=item["id"], input=input)
+            self.opencti.stix_sighting_relationship.update_field(
+                id=item["id"], input=input
+            )
         elif StixCyberObservableTypes.has_value(item["type"]):
             self.opencti.stix_cyber_observable.update_field(id=item["id"], input=input)
         else:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2407,6 +2407,41 @@ class OpenCTIStix2:
 
         return bundle
 
+    def build_patch_input(
+        self,
+        raw_field_patch
+    ):
+        parsed_patch = json.loads(raw_field_patch)
+        full_input = []
+        for key in parsed_patch:
+            value = parsed_patch[key]
+            if len(value['replacedValue']) > 0:
+                replace_input = {'key': key, 'value': value['replacedValue'], 'operation': 'replace'}
+                full_input.append(replace_input)
+            else:
+                if len(value['addedValue']) > 0:
+                    add_input = {'key': key, 'value': value['addedValue'], 'operation': 'add'}
+                    full_input.append(add_input)
+                if len(value['removedValue']) > 0:
+                    add_input = {'key': key, 'value': value['removedValue'], 'operation': 'remove'}
+                    full_input.append(add_input)
+
+        return full_input
+
+    def apply_patch(
+        self,
+        item
+    ):
+        input = self.build_patch_input(item["opencti_field_patch"])
+        if item["type"] == "relationship":
+            self.opencti.stix_core_relationship.update_field(id=item["id"], input=input)
+        elif item["type"] == "sighting":
+            self.opencti.stix_sighting_relationship.update_field(id=item["id"], input=input)
+        elif StixCyberObservableTypes.has_value(item["type"]):
+            self.opencti.stix_cyber_observable.update_field(id=item["id"], input=input)
+        else:
+            self.opencti.stix_domain_object.update_field(id=item["id"], input=input)
+
     def import_item(
         self,
         item,
@@ -2426,6 +2461,8 @@ class OpenCTIStix2:
                     target_id = item["merge_target_id"]
                     source_ids = item["merge_source_ids"]
                     self.opencti.stix.merge(id=target_id, object_ids=source_ids)
+                elif item["opencti_operation"] == "patch":
+                    self.apply_patch(item=item)
                 else:
                     raise ValueError("Not supported opencti_operation")
             elif item["type"] == "relationship":

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2407,12 +2407,8 @@ class OpenCTIStix2:
 
         return bundle
 
-    def get_patch_input(self, raw_field_patch):
-        parsed_patch = json.loads(raw_field_patch)
-        return parsed_patch
-
     def apply_patch(self, item):
-        input = self.get_patch_input(item["opencti_field_patch"])
+        input = item["opencti_field_patch"]
         if item["type"] == "relationship":
             self.opencti.stix_core_relationship.update_field(id=item["id"], input=input)
         elif item["type"] == "sighting":


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->
Linked PR: https://github.com/OpenCTI-Platform/opencti/pull/9504

### Proposed changes

* imported bundle can now contain a `opencti_operation` with a `'patch'` value. When that is the case, the patch contained in the `opencti_field_patch` of the bundle is used to execute a field patch on the imported entity instead of an upsert

### Related issues

* opencti #6728

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
