### PR TITLE
[client] remove hardcoded first value in list method when using getAll

### DIFF
--- a/pycti/entities/opencti_attack_pattern.py
+++ b/pycti/entities/opencti_attack_pattern.py
@@ -256,8 +256,6 @@ class AttackPattern:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Attack-Patterns with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_campaign.py
+++ b/pycti/entities/opencti_campaign.py
@@ -241,8 +241,6 @@ class Campaign:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Campaigns with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_case_incident.py
+++ b/pycti/entities/opencti_case_incident.py
@@ -467,7 +467,7 @@ class CaseIncident:
 
     """
         List Case Incident objects
-        
+
         :param filters: the filters to apply
         :param search: the search keyword
         :param first: return the first n rows from the after ID (or the beginning if not set)
@@ -486,8 +486,6 @@ class CaseIncident:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Case Incidents with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_case_rfi.py
+++ b/pycti/entities/opencti_case_rfi.py
@@ -206,7 +206,7 @@ class CaseRfi:
                         }
                         ... on StixCyberObservable {
                             observable_value
-                        }                        
+                        }
                         ... on StixCoreRelationship {
                             standard_id
                             spec_version
@@ -417,7 +417,7 @@ class CaseRfi:
                         }
                         ... on StixCyberObservable {
                             observable_value
-                        }                        
+                        }
                         ... on StixCoreRelationship {
                             standard_id
                             spec_version
@@ -465,7 +465,7 @@ class CaseRfi:
 
     """
         List Case Rfi objects
-        
+
         :param filters: the filters to apply
         :param search: the search keyword
         :param first: return the first n rows from the after ID (or the beginning if not set)
@@ -484,8 +484,6 @@ class CaseRfi:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Case Rfis with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_case_rft.py
+++ b/pycti/entities/opencti_case_rft.py
@@ -206,7 +206,7 @@ class CaseRft:
                         }
                         ... on StixCyberObservable {
                             observable_value
-                        }                        
+                        }
                         ... on StixCoreRelationship {
                             standard_id
                             spec_version
@@ -417,7 +417,7 @@ class CaseRft:
                             }
                             ... on StixCyberObservable {
                                 observable_value
-                            }                        
+                            }
                             ... on StixCoreRelationship {
                                 standard_id
                                 spec_version
@@ -465,7 +465,7 @@ class CaseRft:
 
     """
         List Case Rft objects
-        
+
         :param filters: the filters to apply
         :param search: the search keyword
         :param first: return the first n rows from the after ID (or the beginning if not set)
@@ -484,8 +484,6 @@ class CaseRft:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
         self.opencti.app_logger.info(
             "Listing Case Rfts with filters", {"filters": json.dumps(filters)}
         )

--- a/pycti/entities/opencti_channel.py
+++ b/pycti/entities/opencti_channel.py
@@ -237,8 +237,6 @@ class Channel:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Channels with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_course_of_action.py
+++ b/pycti/entities/opencti_course_of_action.py
@@ -229,8 +229,6 @@ class CourseOfAction:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Courses-Of-Action with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_data_component.py
+++ b/pycti/entities/opencti_data_component.py
@@ -271,8 +271,6 @@ class DataComponent:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Data-Components with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_data_source.py
+++ b/pycti/entities/opencti_data_source.py
@@ -229,8 +229,6 @@ class DataSource:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Data-Sources with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_event.py
+++ b/pycti/entities/opencti_event.py
@@ -241,8 +241,6 @@ class Event:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Events with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_external_reference.py
+++ b/pycti/entities/opencti_external_reference.py
@@ -93,8 +93,6 @@ class ExternalReference:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing External-Reference with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_feedback.py
+++ b/pycti/entities/opencti_feedback.py
@@ -444,8 +444,6 @@ class Feedback:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Feedbacks with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_grouping.py
+++ b/pycti/entities/opencti_grouping.py
@@ -434,8 +434,6 @@ class Grouping:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Groupings with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_identity.py
+++ b/pycti/entities/opencti_identity.py
@@ -258,8 +258,6 @@ class Identity:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Identities with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_incident.py
+++ b/pycti/entities/opencti_incident.py
@@ -250,8 +250,6 @@ class Incident:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Incidents with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_infrastructure.py
+++ b/pycti/entities/opencti_infrastructure.py
@@ -270,8 +270,6 @@ class Infrastructure:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Infrastructures with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_intrusion_set.py
+++ b/pycti/entities/opencti_intrusion_set.py
@@ -247,8 +247,6 @@ class IntrusionSet:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Intrusion-Sets with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_kill_chain_phase.py
+++ b/pycti/entities/opencti_kill_chain_phase.py
@@ -48,7 +48,6 @@ class KillChainPhase:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_kill_chain_phase.py
+++ b/pycti/entities/opencti_kill_chain_phase.py
@@ -50,8 +50,6 @@ class KillChainPhase:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Kill-Chain-Phase with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_label.py
+++ b/pycti/entities/opencti_label.py
@@ -44,8 +44,6 @@ class Label:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Labels with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_language.py
+++ b/pycti/entities/opencti_language.py
@@ -249,8 +249,6 @@ class Language:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Languages with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_location.py
+++ b/pycti/entities/opencti_location.py
@@ -257,7 +257,6 @@ class Location:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
 

--- a/pycti/entities/opencti_location.py
+++ b/pycti/entities/opencti_location.py
@@ -260,8 +260,6 @@ class Location:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Locations with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_malware.py
+++ b/pycti/entities/opencti_malware.py
@@ -275,8 +275,6 @@ class Malware:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Malwares with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_malware_analysis.py
+++ b/pycti/entities/opencti_malware_analysis.py
@@ -255,8 +255,6 @@ class MalwareAnalysis:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Malware analyses with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_marking_definition.py
+++ b/pycti/entities/opencti_marking_definition.py
@@ -55,8 +55,6 @@ class MarkingDefinition:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Marking-Definitions with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_marking_definition.py
+++ b/pycti/entities/opencti_marking_definition.py
@@ -53,7 +53,6 @@ class MarkingDefinition:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_narrative.py
+++ b/pycti/entities/opencti_narrative.py
@@ -227,8 +227,6 @@ class Narrative:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Narratives with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_note.py
+++ b/pycti/entities/opencti_note.py
@@ -473,8 +473,6 @@ class Note:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Notes with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -464,8 +464,6 @@ class ObservedData:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing ObservedDatas with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_observed_data.py
+++ b/pycti/entities/opencti_observed_data.py
@@ -190,7 +190,7 @@ class ObservedData:
                         }
                         ... on StixCyberObservable {
                             observable_value
-                        }                               
+                        }
                         ... on StixCoreRelationship {
                             standard_id
                             spec_version
@@ -202,7 +202,7 @@ class ObservedData:
                             spec_version
                             created_at
                             updated_at
-                        }                        
+                        }
                     }
                 }
             }
@@ -401,7 +401,7 @@ class ObservedData:
                         }
                         ... on StixCyberObservable {
                             observable_value
-                        }                               
+                        }
                         ... on StixCoreRelationship {
                             standard_id
                             spec_version
@@ -413,7 +413,7 @@ class ObservedData:
                             spec_version
                             created_at
                             updated_at
-                        }                        
+                        }
                     }
                 }
             }
@@ -461,7 +461,6 @@ class ObservedData:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
 

--- a/pycti/entities/opencti_opinion.py
+++ b/pycti/entities/opencti_opinion.py
@@ -250,8 +250,6 @@ class Opinion:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Opinions with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_report.py
+++ b/pycti/entities/opencti_report.py
@@ -504,8 +504,6 @@ class Report:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Reports with filters",

--- a/pycti/entities/opencti_stix_core_object.py
+++ b/pycti/entities/opencti_stix_core_object.py
@@ -1340,8 +1340,6 @@ class StixCoreObject:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Stix-Core-Objects with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_stix_core_relationship.py
+++ b/pycti/entities/opencti_stix_core_relationship.py
@@ -408,8 +408,6 @@ class StixCoreRelationship:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         search = kwargs.get("search", None)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing stix_core_relationships",

--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -48,7 +48,6 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
 
-
         self.opencti.app_logger.info(
             "Listing StixCyberObservables with filters",
             {"filters": json.dumps(filters)},

--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -48,8 +48,6 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
 
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing StixCyberObservables with filters",

--- a/pycti/entities/opencti_stix_domain_object.py
+++ b/pycti/entities/opencti_stix_domain_object.py
@@ -1030,8 +1030,6 @@ class StixDomainObject:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         with_files = kwargs.get("withFiles", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Stix-Domain-Objects with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_stix_nested_ref_relationship.py
+++ b/pycti/entities/opencti_stix_nested_ref_relationship.py
@@ -24,13 +24,13 @@ class StixNestedRefRelationship:
                     standard_id
                     entity_type
                     parent_types
-                } 
+                }
                 ... on StixSightingRelationship {
                     id
                     standard_id
                     entity_type
                     parent_types
-                }                 
+                }
                 ... on StixCyberObservable {
                     observable_value
                 }
@@ -47,13 +47,13 @@ class StixNestedRefRelationship:
                     standard_id
                     entity_type
                     parent_types
-                } 
+                }
                 ... on StixSightingRelationship {
                     id
                     standard_id
                     entity_type
                     parent_types
-                }                 
+                }
                 ... on StixCyberObservable {
                     observable_value
                 }
@@ -92,7 +92,6 @@ class StixNestedRefRelationship:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_stix_nested_ref_relationship.py
+++ b/pycti/entities/opencti_stix_nested_ref_relationship.py
@@ -94,8 +94,6 @@ class StixNestedRefRelationship:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing stix_nested_ref_relationships",

--- a/pycti/entities/opencti_stix_sighting_relationship.py
+++ b/pycti/entities/opencti_stix_sighting_relationship.py
@@ -340,8 +340,6 @@ class StixSightingRelationship:
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
         search = kwargs.get("search", None)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing stix_sighting with {type: stix_sighting}",

--- a/pycti/entities/opencti_task.py
+++ b/pycti/entities/opencti_task.py
@@ -257,8 +257,6 @@ class Task:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Tasks with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_threat_actor.py
+++ b/pycti/entities/opencti_threat_actor.py
@@ -181,8 +181,6 @@ class ThreatActor:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Threat-Actors with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_threat_actor.py
+++ b/pycti/entities/opencti_threat_actor.py
@@ -168,7 +168,6 @@ class ThreatActor:
         :param str after: (optional) OpenCTI object ID of the first row for pagination
         :param str orderBy: (optional) the field to order the response on
         :param bool orderMode: (optional) either "`asc`" or "`desc`"
-        :param bool getAll: (optional) switch to return all entries (be careful to use this without any other filters)
         :param bool withPagination: (optional) switch to use pagination
         """
 
@@ -179,7 +178,6 @@ class ThreatActor:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_threat_actor_group.py
+++ b/pycti/entities/opencti_threat_actor_group.py
@@ -174,8 +174,6 @@ class ThreatActorGroup:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Threat-Actors-Group with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_threat_actor_group.py
+++ b/pycti/entities/opencti_threat_actor_group.py
@@ -161,7 +161,6 @@ class ThreatActorGroup:
         :param str after: (optional) OpenCTI object ID of the first row for pagination
         :param str orderBy: (optional) the field to order the response on
         :param bool orderMode: (optional) either "`asc`" or "`desc`"
-        :param bool getAll: (optional) switch to return all entries (be careful to use this without any other filters)
         :param bool withPagination: (optional) switch to use pagination
         """
 
@@ -172,7 +171,6 @@ class ThreatActorGroup:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_threat_actor_individual.py
+++ b/pycti/entities/opencti_threat_actor_individual.py
@@ -174,8 +174,6 @@ class ThreatActorIndividual:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 500
 
         self.opencti.app_logger.info(
             "Listing Threat-Actors-Individual with filters",

--- a/pycti/entities/opencti_threat_actor_individual.py
+++ b/pycti/entities/opencti_threat_actor_individual.py
@@ -161,7 +161,6 @@ class ThreatActorIndividual:
         :param str after: (optional) OpenCTI object ID of the first row for pagination
         :param str orderBy: (optional) the field to order the response on
         :param bool orderMode: (optional) either "`asc`" or "`desc`"
-        :param bool getAll: (optional) switch to return all entries (be careful to use this without any other filters)
         :param bool withPagination: (optional) switch to use pagination
         """
 
@@ -172,7 +171,6 @@ class ThreatActorIndividual:
         order_by = kwargs.get("orderBy", None)
         order_mode = kwargs.get("orderMode", None)
         custom_attributes = kwargs.get("customAttributes", None)
-        get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
 
         self.opencti.app_logger.info(

--- a/pycti/entities/opencti_tool.py
+++ b/pycti/entities/opencti_tool.py
@@ -158,8 +158,6 @@ class Tool:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Tools with filters", {"filters": json.dumps(filters)}

--- a/pycti/entities/opencti_vulnerability.py
+++ b/pycti/entities/opencti_vulnerability.py
@@ -155,8 +155,6 @@ class Vulnerability:
         custom_attributes = kwargs.get("customAttributes", None)
         get_all = kwargs.get("getAll", False)
         with_pagination = kwargs.get("withPagination", False)
-        if get_all:
-            first = 100
 
         self.opencti.app_logger.info(
             "Listing Vulnerabilities with filters", {"filters": json.dumps(filters)}


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Currently, when listing entities with the `getAll` parameter, the `first` value is overwritten. This PR removes the overwrite of the `first` value when using `getAll` in list methods, for all entities.

### Proposed changes

* Remove the hardcoding of the `first` value when using `getAll` in list methods for all entities.

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/457#event-15973410071

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

PR https://github.com/OpenCTI-Platform/client-python/pull/796 did not fix this related issue.

FYI, the following entities did not use `getAll` and the variable has been removed:

- `pycti/entities/opencti_kill_chain_phase.py`
- `pycti/entities/opencti_location.py`
- `pycti/entities/opencti_marking_definition.py`
- `pycti/entities/opencti_observed_data.py`
- `pycti/entities/opencti_stix_nested_ref_relationship.py`
- `pycti/entities/opencti_threat_actor.py`
- `pycti/entities/opencti_threat_actor_group.py`
- `pycti/entities/opencti_threat_actor_individual.py`
