### PR TITLE
[client] Hide Authorization header (opencti/9693)

### DIFF
--- a/pycti/api/opencti_api_client.py
+++ b/pycti/api/opencti_api_client.py
@@ -224,8 +224,11 @@ class OpenCTIApiClient:
     def set_previous_standard_header(self, previous_standard):
         self.request_headers["previous-standard"] = previous_standard
 
-    def get_request_headers(self):
-        return self.request_headers
+    def get_request_headers(self, hide_token=True):
+        request_headers_copy = self.request_headers.copy()
+        if hide_token and "Authorization" in request_headers_copy:
+            request_headers_copy["Authorization"] = "*****"
+        return request_headers_copy
 
     def set_retry_number(self, retry_number):
         self.request_headers["opencti-retry-number"] = (


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Hide token by default and return request headers copy

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/9693

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

to test locally, you need first to set `json_logging: true` in your config.yml, then you'll need to simulate a ping error on opencti. If you don't know how, you can try to change `getApplicationInfo` like this so that it will send a periodic error : 
```
let index = 0;
export const getApplicationInfo = () => {
  index += 1;
  if (index === 10) {
    index = 0;
    throw FunctionalError('for debug');
  }
  return {
    version: PLATFORM_VERSION,
    debugStats: {}, // Lazy loaded
  };
};
```