### PR TITLE
[client] extend grace period for deprecated "promote" API

### DIFF
--- a/pycti/entities/stix_cyber_observable/opencti_stix_cyber_observable_deprecated.py
+++ b/pycti/entities/stix_cyber_observable/opencti_stix_cyber_observable_deprecated.py
@@ -3,7 +3,7 @@ import deprecation
 
 class StixCyberObservableDeprecatedMixin:
     """
-    deprecated [>=6.2 & <6.5]`
+    deprecated [>=6.2 & <6.8]`
     Promote a Stix-Observable to an Indicator
 
     :param id: the Stix-Observable id

--- a/tests/02-integration/entities/test_observables.py
+++ b/tests/02-integration/entities/test_observables.py
@@ -2,7 +2,7 @@
 
 
 def test_promote_observable_to_indicator_deprecated(api_client):
-    # deprecated [>=6.2 & <6.5]
+    # deprecated [>=6.2 & <6.8]
     obs1 = api_client.stix_cyber_observable.create(
         simple_observable_key="IPv4-Addr.value", simple_observable_value="55.55.55.55"
     )


### PR DESCRIPTION
The deprecation period for API function `promote_to_indicator` is extended to octi 6.8, to let people migrate serenely.

If you are still using this deprecated function, please read https://docs.opencti.io/latest/deployment/breaking-changes/6.2-promote-to-indicator/ 