### PR TITLE
[connector] Replace deprecated datetime.utcnow() in logger's formatter

### DIFF
--- a/pycti/utils/opencti_logger.py
+++ b/pycti/utils/opencti_logger.py
@@ -1,5 +1,5 @@
-import datetime
 import logging
+from datetime import datetime, timezone
 
 from pythonjsonlogger import jsonlogger
 
@@ -9,8 +9,8 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
         if not log_record.get("timestamp"):
             # This doesn't use record.created, so it is slightly off
-            now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-            log_record["timestamp"] = now
+            now = datetime.now(tz=timezone.utc)
+            log_record["timestamp"] = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         if log_record.get("level"):
             log_record["level"] = log_record["level"].upper()
         else:


### PR DESCRIPTION
### Proposed changes

* replace `datetime.utcnow()` with `datetime.now(tz=timezone.utc)`

### Related issues

* [#3334](https://github.com/OpenCTI-Platform/connectors/issues/3334)

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

Quick fix to avoid errors during logging on a `sys.exit()` signal. A global rework of the AppLogger will be done soon.
