### PR TITLE
[deps]: loose opentelemetry-xxx required versions (#818)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ requests~=2.32.2
 setuptools~=71.1.0
 cachetools~=5.5.0
 prometheus-client~=0.21.1
-opentelemetry-api~=1.22.0
-opentelemetry-sdk~=1.22.0
+opentelemetry-api>=1.22.0,<=1.30.0
+opentelemetry-sdk>=1.22.0,<=1.30.0
 deprecation~=2.1.0
 # OpenCTI
 filigran-sseclient>=1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,8 @@ install_requires =
     setuptools~=71.1.0
     cachetools~=5.5.0
     prometheus-client~=0.21.1
-    opentelemetry-api~=1.22.0
-    opentelemetry-sdk~=1.22.0
+    opentelemetry-api>=1.22.0,<=1.30.0
+    opentelemetry-sdk>=1.22.0,<=1.30.0
     deprecation~=2.1.0
     # OpenCTI
     filigran-sseclient>=1.0.2


### PR DESCRIPTION
### Proposed changes

* Loose opentelemetry-api/sdk required versions in dependencies

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/818

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality


### Further comments

Opentelemetry python packages available versions are.

```bash
$ python -m pip index versions opentelemetry-sdk
Available versions: 1.30.0, 1.29.0, 1.28.2, 1.28.1, 1.28.0, 1.27.0, 1.26.0, 1.25.0, 1.24.0, 1.23.0, 1.22.0, 1.21.0, 1.20.0, 1.19.0, 1.18.0, 1.17.0, 1.16.0, 1.15.0, 1.14.0, 1.13.0, 1.12.0, 1.11.1, 1.11.0, 1.10.0, 1.9.1, 1.9.0, 1.8.0, 1.7.1, 1.7.0, 1.6.2, 1.6.1, 1.6.0, 1.5.0, 1.4.1, 1.4.0, 1.3.0, 1.2.0, 1.1.0, 1.0.0
```

We are currently using 1.22.0, released in December 2023 ! https://github.com/open-telemetry/opentelemetry-python/commit/e6602ffc7434929fa377beae2f0d14f6d6993997

Using the `tox `tool, and based on successful package installation with `pip `and tests performed with `pytest`, we can conclude that we are, at a minimum, compatible with `opentelemetry-sdk/api` versions [1.22.0 to 1.30.0] when using Python [3.8 to 3.12].

See Notion page for details : https://www.notion.so/filigran/Loose-OpenTelemetry-required-versions-in-opencti-python-client-19d8fce17f2a80128378d53a1a071895?pvs=4