### PR TITLE
[client] only add draft_id to work when draft is created by connector (opencti #9300)

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1670,8 +1670,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                     self.connector_logger.error("Draft couldn't be created")
                     return []
                 if work_id:
-                    if draft_id:
-                        self.api.work.add_draft_context(work_id, draft_id)
+                    self.api.work.add_draft_context(work_id, draft_id)
 
         # If directory setup, write the bundle to the target directory
         if bundle_send_to_directory and bundle_send_to_directory_path is not None:
@@ -1747,8 +1746,6 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         if bundle_send_to_queue:
             if work_id:
                 self.api.work.add_expectations(work_id, expectations_number)
-                if draft_id:
-                    self.api.work.add_draft_context(work_id, draft_id)
             if entities_types is None:
                 entities_types = []
             if self.queue_protocol == "amqp":

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1669,6 +1669,9 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
                 if not draft_id:
                     self.connector_logger.error("Draft couldn't be created")
                     return []
+                if work_id:
+                    if draft_id:
+                        self.api.work.add_draft_context(work_id, draft_id)
 
         # If directory setup, write the bundle to the target directory
         if bundle_send_to_directory and bundle_send_to_directory_path is not None:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2431,7 +2431,9 @@ class OpenCTIStix2:
                     )
 
     def apply_patch(self, item):
-        field_patch = self.opencti.get_attribute_in_extension("opencti_field_patch", item)
+        field_patch = self.opencti.get_attribute_in_extension(
+            "opencti_field_patch", item
+        )
         if field_patch is None:
             field_patch = item["opencti_field_patch"]
         field_patch_without_files = [
@@ -2484,7 +2486,9 @@ class OpenCTIStix2:
         worker_logger = self.opencti.logger_class("worker")
         try:
             self.opencti.set_retry_number(processing_count)
-            opencti_operation = self.opencti.get_attribute_in_extension("opencti_operation", item)
+            opencti_operation = self.opencti.get_attribute_in_extension(
+                "opencti_operation", item
+            )
             if opencti_operation is not None:
                 self.apply_opencti_operation(item, opencti_operation)
             elif "opencti_operation" in item:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2431,7 +2431,9 @@ class OpenCTIStix2:
                     )
 
     def apply_patch(self, item):
-        field_patch = item["opencti_field_patch"]
+        field_patch = self.opencti.get_attribute_in_extension("opencti_field_patch", item)
+        if field_patch is None:
+            field_patch = item["opencti_field_patch"]
         field_patch_without_files = [
             op for op in field_patch if op["key"] != "x_opencti_files"
         ]
@@ -2458,6 +2460,19 @@ class OpenCTIStix2:
                 )
         self.apply_patch_files(item)
 
+    def apply_opencti_operation(self, item, operation):
+        if operation == "delete":
+            delete_id = item["id"]
+            self.opencti.stix.delete(id=delete_id)
+        elif operation == "merge":
+            target_id = item["merge_target_id"]
+            source_ids = item["merge_source_ids"]
+            self.opencti.stix.merge(id=target_id, object_ids=source_ids)
+        elif operation == "patch":
+            self.apply_patch(item=item)
+        else:
+            raise ValueError("Not supported opencti_operation")
+
     def import_item(
         self,
         item,
@@ -2469,18 +2484,11 @@ class OpenCTIStix2:
         worker_logger = self.opencti.logger_class("worker")
         try:
             self.opencti.set_retry_number(processing_count)
-            if "opencti_operation" in item:
-                if item["opencti_operation"] == "delete":
-                    delete_id = item["id"]
-                    self.opencti.stix.delete(id=delete_id)
-                elif item["opencti_operation"] == "merge":
-                    target_id = item["merge_target_id"]
-                    source_ids = item["merge_source_ids"]
-                    self.opencti.stix.merge(id=target_id, object_ids=source_ids)
-                elif item["opencti_operation"] == "patch":
-                    self.apply_patch(item=item)
-                else:
-                    raise ValueError("Not supported opencti_operation")
+            opencti_operation = self.opencti.get_attribute_in_extension("opencti_operation", item)
+            if opencti_operation is not None:
+                self.apply_opencti_operation(item, opencti_operation)
+            elif "opencti_operation" in item:
+                self.apply_opencti_operation(item, item["opencti_operation"])
             elif item["type"] == "relationship":
                 # Import relationship
                 self.import_relationship(item, update, types)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* only add draft_id to work when draft is created by connector
*

### Related issues

* opencti #9300

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
