### PR TITLE
[deps]: loose requests required versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-magic-bin~=0.4.14; sys_platform == 'win32'
 python_json_logger~=2.0.4
 PyYAML~=6.0
 pydantic>=2.8.2,<2.11
-requests~=2.32.2
+requests>=2.32.0, <=2.32.3
 setuptools~=71.1.0
 cachetools~=5.5.0
 prometheus-client~=0.21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-magic-bin~=0.4.14; sys_platform == 'win32'
 python_json_logger~=2.0.4
 PyYAML~=6.0
 pydantic>=2.8.2,<2.11
-requests>=2.32.0, <=2.32.3
+requests>=2.32.0,<=2.32.3
 setuptools~=71.1.0
 cachetools~=5.5.0
 prometheus-client~=0.21.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     python-magic-bin~=0.4.14; sys_platform == 'win32'
     python_json_logger~=2.0.4
     PyYAML~=6.0
-    requests~=2.32.2
+    requests>=2.32.0,<=2.32.3
     setuptools~=71.1.0
     cachetools~=5.5.0
     prometheus-client~=0.21.1


### PR DESCRIPTION
### Proposed changes

* Loose `requests `required versions in dependencies

### Related issues

* https://github.com/OpenCTI-Platform/client-python/issues/857

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

### Further comments

From [Changelog ](https://requests.readthedocs.io/en/latest/community/updates/#release-history)(consulted on March 6, 2025) last Security issue was patch in 2.32..0. So we tested from this version to latest one with python versions 3.8 -> 3.12.

Using the tox tool, and based on successful package installation with `pip`, vulnerability check with `pip-audit` and tests performed with `pytest`, we can conclude that we are, at a minimum, compatible with requests versions [2.32.0 to 2.32.3] when using Python [3.8 to 3.12].

Investigation Notion Page : https://www.notion.so/filigran/Loose-Requests-required-versions-in-opencti-python-client-1ae8fce17f2a809c9eebfec93400b1c4?pvs=4

