### PR TITLE
[client] do not register API listening URI when using AMQP protocol

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1102,7 +1102,11 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             self.connect_auto,
             self.connect_only_contextual,
             playbook_compatible,
-            self.listen_protocol_api_uri + self.listen_protocol_api_path,
+            (
+                self.listen_protocol_api_uri + self.listen_protocol_api_path
+                if self.listen_protocol == "API"
+                else None
+            ),
         )
         connector_configuration = self.api.connector.register(self.connector)
         self.connector_logger.info(


### PR DESCRIPTION
### Proposed changes

* OpenCTIConnector last argument is listen_callback_uri with default value None, which needs to be set when using protocol API instead of default AMQP. However, previous code in the connector helper always sets the argument to an URL based on two other config variables with default values, resulting in all connectors registering with a listen_callback_uri. The protocol is not kept in OpenCTI and the workers check listen_callback_uri to determine if they need to connect to the URI. All connectors are then trying to reach the default URI when using AMQP protocol.
This change fixes it by setting the listen_callback_uri argument only if API protocol.


- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
