### PR TITLE
refactor: enums to use CaseInsensitiveMixin for has_value

### DIFF
--- a/pycti/utils/constants.py
+++ b/pycti/utils/constants.py
@@ -12,7 +12,22 @@ from stix2.properties import (
 from stix2.utils import NOW
 
 
-class StixCyberObservableTypes(Enum):
+class CaseInsensitiveMixin:
+    """Mixin providing case-insensitive value checking for Enum classes."""
+    _lower_values_cache = None
+
+    @classmethod
+    def _get_lower_values(cls):
+        if cls._lower_values_cache is None:
+            cls._lower_values_cache = {v.lower() for v in cls._value2member_map_}
+        return cls._lower_values_cache
+
+    @classmethod
+    def has_value(cls, value):
+        return value.lower() in cls._get_lower_values()
+
+
+class StixCyberObservableTypes(CaseInsensitiveMixin, Enum):
     AUTONOMOUS_SYSTEM = "Autonomous-System"
     DIRECTORY = "Directory"
     DOMAIN_NAME = "Domain-Name"
@@ -47,48 +62,28 @@ class StixCyberObservableTypes(Enum):
     SIMPLE_OBSERVABLE = "Simple-Observable"
     PERSONA = "Persona"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class IdentityTypes(Enum):
+class IdentityTypes(CaseInsensitiveMixin, Enum):
     SECTOR = "Sector"
     ORGANIZATION = "Organization"
     INDIVIDUAL = "Individual"
     SYSTEM = "System"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class ThreatActorTypes(Enum):
+class ThreatActorTypes(CaseInsensitiveMixin, Enum):
     THREAT_ACTOR_GROUP = "Threat-Actor-Group"
     THREAT_ACTOR_INDIVIDUAL = "Threat-Actor-Individual"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class LocationTypes(Enum):
+class LocationTypes(CaseInsensitiveMixin, Enum):
     REGION = "Region"
     COUNTRY = "Country"
     ADMINISTRATIVE_AREA = "Administrative-Area"
     CITY = "City"
     POSITION = "Position"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class ContainerTypes(Enum):
+class ContainerTypes(CaseInsensitiveMixin, Enum):
     NOTE = "Note"
     OBSERVED_DATA = "Observed-Data"
     OPINION = "Opinion"
@@ -96,25 +91,15 @@ class ContainerTypes(Enum):
     GROUPING = "Grouping"
     CASE = "Case"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class StixMetaTypes(Enum):
+class StixMetaTypes(CaseInsensitiveMixin, Enum):
     MARKING_DEFINITION = "Marking-Definition"
     LABEL = "Label"
     EXTERNAL_REFERENCE = "External-Reference"
     KILL_CHAIN_PHASE = "Kill-Chain-Phase"
 
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
-
-class MultipleRefRelationship(Enum):
+class MultipleRefRelationship(CaseInsensitiveMixin, Enum):
     OPERATING_SYSTEM = "operating-system"
     SAMPLE = "sample"
     CONTAINS = "contains"
@@ -131,11 +116,6 @@ class MultipleRefRelationship(Enum):
     SERVICE_DDL = "service-dll"
     INSTALLED_SOFTWARE = "installed-software"
     RELATION_ANALYSIS_SCO = "analysis-sco"
-
-    @classmethod
-    def has_value(cls, value):
-        lower_attr = list(map(lambda x: x.lower(), cls._value2member_map_))
-        return value.lower() in lower_attr
 
 
 # Custom objects

--- a/pycti/utils/constants.py
+++ b/pycti/utils/constants.py
@@ -14,6 +14,7 @@ from stix2.utils import NOW
 
 class CaseInsensitiveMixin:
     """Mixin providing case-insensitive value checking for Enum classes."""
+
     _lower_values_cache = None
 
     @classmethod


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Added `CaseInsensitiveMixin` to improve code reuse for case-insensitive value checking across Enum classes.
* Applied the mixin to the Enuns `StixCyberObservableTypes`, `IdentityTypes`, `ThreatActorTypes`, `LocationTypes`, `ContainerTypes`, `StixMetaTypes`, and `MultipleRefRelationship` to remove duplicated `has_value` function logic.
* Updated the logic in `has_value` to use a set (O(1) lookup) instead of a list (O(N) lookup) and added caching for `lower_values` to avoid recreating it on every call.

This change follows the DRY principle by centralizing case-insensitive checks in a single mixin, making the code cleaner and easier to maintain. It's not a major performance optimization, but it's a nice improvement. I’ve included a benchmark below to show the results.

**Benchmark code and results**:
code: https://gist.github.com/allrob23/03382afaffec1a31472ed6fa90fdeb52

**Result**
Original: 0.004698 seconds
Refactored: 0.000227 seconds


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...


