### PR TITLE
[client] now use internal id when possible for patch operations

### DIFF
--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2419,7 +2419,6 @@ class OpenCTIStix2:
             (op for op in field_patch if op["key"] == "x_opencti_files"), None
         )
         item_id = self.opencti.get_attribute_in_extension("id", item)
-        worker_logger = self.opencti.logger_class("worker")
         if item_id is None:
             item_id = item["id"]
         do_add_file = self.opencti.stix_domain_object.add_file

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2418,6 +2418,13 @@ class OpenCTIStix2:
         field_patch_files = next(
             (op for op in field_patch if op["key"] == "x_opencti_files"), None
         )
+        item_id = self.opencti.get_attribute_in_extension(
+            "id", item
+        )
+        worker_logger = self.opencti.logger_class("worker")
+        worker_logger.warning("id found: " + item_id)
+        if item_id is None:
+            item_id = item["id"]
         do_add_file = self.opencti.stix_domain_object.add_file
         if StixCyberObservableTypes.has_value(item["type"]):
             do_add_file = self.opencti.stix_cyber_observable.add_file
@@ -2427,7 +2434,7 @@ class OpenCTIStix2:
             for file in field_patch_files["value"]:
                 if "data" in file:
                     do_add_file(
-                        id=item["id"],
+                        id=item_id,
                         file_name=file["name"],
                         version=file.get("version", None),
                         data=base64.b64decode(file["data"]),
@@ -2445,26 +2452,31 @@ class OpenCTIStix2:
         field_patch_without_files = [
             op for op in field_patch if op["key"] != "x_opencti_files"
         ]
+        item_id = self.opencti.get_attribute_in_extension(
+            "id", item
+        )
+        if item_id is None:
+            item_id = item["id"]
         if len(field_patch_without_files) > 0:
             if item["type"] == "relationship":
                 self.opencti.stix_core_relationship.update_field(
-                    id=item["id"], input=field_patch_without_files
+                    id=item_id, input=field_patch_without_files
                 )
             elif item["type"] == "sighting":
                 self.opencti.stix_sighting_relationship.update_field(
-                    id=item["id"], input=field_patch_without_files
+                    id=item_id, input=field_patch_without_files
                 )
             elif StixCyberObservableTypes.has_value(item["type"]):
                 self.opencti.stix_cyber_observable.update_field(
-                    id=item["id"], input=field_patch_without_files
+                    id=item_id, input=field_patch_without_files
                 )
             elif item["type"] == "external-reference":
                 self.opencti.external_reference.update_field(
-                    id=item["id"], input=field_patch_without_files
+                    id=item_id, input=field_patch_without_files
                 )
             else:
                 self.opencti.stix_domain_object.update_field(
-                    id=item["id"], input=field_patch_without_files
+                    id=item_id, input=field_patch_without_files
                 )
         self.apply_patch_files(item)
 
@@ -2707,6 +2719,10 @@ class OpenCTIStix2:
             # Platform does not know what to do and raises an error:
             # That also works for missing reference with too much execution
             else:
+                worker_logger.error(
+                    "Message reprocess for bad gateway",
+                    {"count": processing_count},
+                )
                 bundles_technical_error_counter.add(1)
                 if work_id is not None:
                     item_str = json.dumps(item)

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2418,11 +2418,8 @@ class OpenCTIStix2:
         field_patch_files = next(
             (op for op in field_patch if op["key"] == "x_opencti_files"), None
         )
-        item_id = self.opencti.get_attribute_in_extension(
-            "id", item
-        )
+        item_id = self.opencti.get_attribute_in_extension("id", item)
         worker_logger = self.opencti.logger_class("worker")
-        worker_logger.warning("id found: " + item_id)
         if item_id is None:
             item_id = item["id"]
         do_add_file = self.opencti.stix_domain_object.add_file
@@ -2452,9 +2449,7 @@ class OpenCTIStix2:
         field_patch_without_files = [
             op for op in field_patch if op["key"] != "x_opencti_files"
         ]
-        item_id = self.opencti.get_attribute_in_extension(
-            "id", item
-        )
+        item_id = self.opencti.get_attribute_in_extension("id", item)
         if item_id is None:
             item_id = item["id"]
         if len(field_patch_without_files) > 0:
@@ -2719,10 +2714,6 @@ class OpenCTIStix2:
             # Platform does not know what to do and raises an error:
             # That also works for missing reference with too much execution
             else:
-                worker_logger.error(
-                    "Message reprocess for bad gateway",
-                    {"count": processing_count},
-                )
                 bundles_technical_error_counter.add(1)
                 if work_id is not None:
                     item_str = json.dumps(item)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use internal_id for patch operation instead of standard_id, to handle patches that cause a standard_id change

related opencti PR: https://github.com/OpenCTI-Platform/opencti/pull/10825

### Related issues

* opencti #10817
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
