### PR TITLE
[client] handle src_ref and dst_ref during network traffic creation (opencti #10869)

### DIFF
--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -747,6 +747,16 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                         if "dst_port" in observable_data
                         else None
                     ),
+                    "networkSrc": (
+                        observable_data["src_ref"]
+                        if "src_ref" in observable_data
+                        else None
+                    ),
+                    "networkDst": (
+                        observable_data["dst_ref"]
+                        if "dst_ref" in observable_data
+                        else None
+                    ),
                     "protocols": (
                         observable_data["protocols"]
                         if "protocols" in observable_data


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* src_ref and dst_ref weren't handled directly in creation. This could cause unwanted deduplication to occur
*

### Related issues

* opencti #10869
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
