### PR TITLE
[client] report discarded objects during splitting as processed in work (opencti #11359)

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1921,6 +1921,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
         (
             expectations_number,
             bundles,
+            _
         ) = stix2_splitter.split_bundle_with_expectations(
             bundle=bundle,
             use_json=True,

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1918,7 +1918,7 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             os.rename(write_file, final_write_file)
 
         stix2_splitter = OpenCTIStix2Splitter()
-        (expectations_number, bundles, _) = (
+        (expectations_number, _, bundles) = (
             stix2_splitter.split_bundle_with_expectations(
                 bundle=bundle,
                 use_json=True,

--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -1918,15 +1918,13 @@ class OpenCTIConnectorHelper:  # pylint: disable=too-many-public-methods
             os.rename(write_file, final_write_file)
 
         stix2_splitter = OpenCTIStix2Splitter()
-        (
-            expectations_number,
-            bundles,
-            _
-        ) = stix2_splitter.split_bundle_with_expectations(
-            bundle=bundle,
-            use_json=True,
-            event_version=event_version,
-            cleanup_inconsistent_bundle=cleanup_inconsistent_bundle,
+        (expectations_number, bundles, _) = (
+            stix2_splitter.split_bundle_with_expectations(
+                bundle=bundle,
+                use_json=True,
+                event_version=event_version,
+                cleanup_inconsistent_bundle=cleanup_inconsistent_bundle,
+            )
         )
 
         if len(bundles) == 0:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2748,9 +2748,15 @@ class OpenCTIStix2:
         )
 
         stix2_splitter = OpenCTIStix2Splitter()
-        _, bundles = stix2_splitter.split_bundle_with_expectations(
+        _, nb_incompatible_elements, bundles = stix2_splitter.split_bundle_with_expectations(
             stix_bundle, False, event_version
         )
+
+        # Report every element ignored during bundle splitting
+        if work_id is not None:
+            for i in range(nb_incompatible_elements):
+                self.opencti.work.report_expectation(work_id, None)
+
         # Import every element in a specific order
         imported_elements = []
         for bundle in bundles:

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2748,8 +2748,10 @@ class OpenCTIStix2:
         )
 
         stix2_splitter = OpenCTIStix2Splitter()
-        _, nb_incompatible_elements, bundles = stix2_splitter.split_bundle_with_expectations(
-            stix_bundle, False, event_version
+        _, nb_incompatible_elements, bundles = (
+            stix2_splitter.split_bundle_with_expectations(
+                stix_bundle, False, event_version
+            )
         )
 
         # Report every element ignored during bundle splitting

--- a/pycti/utils/opencti_stix2.py
+++ b/pycti/utils/opencti_stix2.py
@@ -2748,7 +2748,7 @@ class OpenCTIStix2:
         )
 
         stix2_splitter = OpenCTIStix2Splitter()
-        _, nb_incompatible_elements, bundles = (
+        _, incompatible_elements, bundles = (
             stix2_splitter.split_bundle_with_expectations(
                 stix_bundle, False, event_version
             )
@@ -2756,8 +2756,16 @@ class OpenCTIStix2:
 
         # Report every element ignored during bundle splitting
         if work_id is not None:
-            for i in range(nb_incompatible_elements):
-                self.opencti.work.report_expectation(work_id, None)
+            for incompatible_element in incompatible_elements:
+                self.opencti.work.report_expectation(
+                    work_id,
+                    {
+                        "error": "Incompatible element in bundle",
+                        "source": "Element "
+                        + incompatible_element["id"]
+                        + " is incompatible and couldn't be processed",
+                    },
+                )
 
         # Import every element in a specific order
         imported_elements = []

--- a/pycti/utils/opencti_stix2_splitter.py
+++ b/pycti/utils/opencti_stix2_splitter.py
@@ -35,6 +35,7 @@ class OpenCTIStix2Splitter:
         self.cache_index = {}
         self.cache_refs = {}
         self.elements = []
+        self.nb_incompatible_items = 0
 
     def get_internal_ids_in_extension(self, item):
         ids = []
@@ -189,6 +190,8 @@ class OpenCTIStix2Splitter:
                 is_compatible = is_id_supported(item_id)
             if is_compatible:
                 self.elements.append(item)
+            else:
+                self.nb_incompatible_items = self.nb_incompatible_items + 1
             self.cache_index[item_id] = item
             for internal_id in self.get_internal_ids_in_extension(item):
                 self.cache_index[internal_id] = item
@@ -201,7 +204,7 @@ class OpenCTIStix2Splitter:
         use_json=True,
         event_version=None,
         cleanup_inconsistent_bundle=False,
-    ) -> Tuple[int, list]:
+    ) -> Tuple[int, int, list]:
         """splits a valid stix2 bundle into a list of bundles"""
         if use_json:
             try:
@@ -251,11 +254,11 @@ class OpenCTIStix2Splitter:
                 )
             )
 
-        return number_expectations, bundles
+        return number_expectations, self.nb_incompatible_items, bundles
 
     @deprecated("Use split_bundle_with_expectations instead")
     def split_bundle(self, bundle, use_json=True, event_version=None) -> list:
-        expectations, bundles = self.split_bundle_with_expectations(
+        _, _, bundles = self.split_bundle_with_expectations(
             bundle, use_json, event_version
         )
         return bundles

--- a/pycti/utils/opencti_stix2_splitter.py
+++ b/pycti/utils/opencti_stix2_splitter.py
@@ -35,7 +35,7 @@ class OpenCTIStix2Splitter:
         self.cache_index = {}
         self.cache_refs = {}
         self.elements = []
-        self.nb_incompatible_items = 0
+        self.incompatible_items = []
 
     def get_internal_ids_in_extension(self, item):
         ids = []
@@ -191,7 +191,7 @@ class OpenCTIStix2Splitter:
             if is_compatible:
                 self.elements.append(item)
             else:
-                self.nb_incompatible_items = self.nb_incompatible_items + 1
+                self.incompatible_items.append(item)
             self.cache_index[item_id] = item
             for internal_id in self.get_internal_ids_in_extension(item):
                 self.cache_index[internal_id] = item
@@ -204,7 +204,7 @@ class OpenCTIStix2Splitter:
         use_json=True,
         event_version=None,
         cleanup_inconsistent_bundle=False,
-    ) -> Tuple[int, int, list]:
+    ) -> Tuple[int, list, list]:
         """splits a valid stix2 bundle into a list of bundles"""
         if use_json:
             try:
@@ -254,7 +254,7 @@ class OpenCTIStix2Splitter:
                 )
             )
 
-        return number_expectations, self.nb_incompatible_items, bundles
+        return number_expectations, self.incompatible_items, bundles
 
     @deprecated("Use split_bundle_with_expectations instead")
     def split_bundle(self, bundle, use_json=True, event_version=None) -> list:

--- a/tests/01-unit/utils/test_opencti_stix2_splitter.py
+++ b/tests/01-unit/utils/test_opencti_stix2_splitter.py
@@ -10,7 +10,7 @@ def test_split_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/enterprise-attack.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 7016
 
 
@@ -18,7 +18,7 @@ def test_split_test_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/DATA-TEST-STIX2_v2.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 59
     base_bundles = json.loads(content)["objects"]
     for base in base_bundles:
@@ -40,13 +40,13 @@ def test_split_mono_entity_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/mono-bundle-entity.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 1
     json_bundle = json.loads(bundles[0])["objects"][0]
     assert json_bundle["created_by_ref"] == "fa42a846-8d90-4e51-bc29-71d5b4802168"
     # Split with cleanup_inconsistent_bundle
     stix_splitter = OpenCTIStix2Splitter()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
         bundle=content, cleanup_inconsistent_bundle=True
     )
     assert expectations == 1
@@ -58,11 +58,11 @@ def test_split_mono_relationship_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/mono-bundle-relationship.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 1
     # Split with cleanup_inconsistent_bundle
     stix_splitter = OpenCTIStix2Splitter()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
         bundle=content, cleanup_inconsistent_bundle=True
     )
     assert expectations == 0
@@ -72,7 +72,7 @@ def test_split_capec_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/mitre_att_capec.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 2610
 
 
@@ -80,11 +80,11 @@ def test_split_internal_ids_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/bundle_with_internal_ids.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 4
     # Split with cleanup_inconsistent_bundle
     stix_splitter = OpenCTIStix2Splitter()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
         bundle=content, cleanup_inconsistent_bundle=True
     )
     assert expectations == 4
@@ -101,11 +101,11 @@ def test_split_missing_refs_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/missing_refs.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 4
     # Split with cleanup_inconsistent_bundle
     stix_splitter = OpenCTIStix2Splitter()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(
         bundle=content, cleanup_inconsistent_bundle=True
     )
     assert expectations == 3
@@ -115,7 +115,7 @@ def test_split_cyclic_bundle():
     stix_splitter = OpenCTIStix2Splitter()
     with open("./tests/data/cyclic-bundle.json") as file:
         content = file.read()
-    expectations, bundles = stix_splitter.split_bundle_with_expectations(content)
+    expectations, _, bundles = stix_splitter.split_bundle_with_expectations(content)
     assert expectations == 6
     for bundle in bundles:
         json_bundle = json.loads(bundle)


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* split_bundle_with_expectations now reports the number of discarded elements due to incompatible type
* when splitting bundle in import_bundle, we now report_expectation with an error for every discarded element
* changed all calls to split_bundle_with_expectations  to handle new signature

result of new report expectation with error:
![image](https://github.com/user-attachments/assets/d2c75a4e-2b3c-4e4b-af46-5de4e13b147f)


octi PR: https://github.com/OpenCTI-Platform/opencti/pull/11365

### Related issues

* opencti #11359
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
