### PR TITLE
[client] Enriching External Reference Objects from User Interface produces GraphQL error (#11548)

### DIFF
--- a/pycti/entities/opencti_stix_core_object.py
+++ b/pycti/entities/opencti_stix_core_object.py
@@ -1922,7 +1922,7 @@ class StixCoreObject:
             query,
             {
                 "id": element_id,
-                "connectorId": connector_ids,
+                "connectorIds": connector_ids,
             },
         )
 


### PR DESCRIPTION
### Proposed changes

* add missing "s" in connectorIds

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/11548