### PR TITLE
[client] Fix windows registry observable creation (#974)

### DIFF
--- a/pycti/entities/opencti_stix_cyber_observable.py
+++ b/pycti/entities/opencti_stix_cyber_observable.py
@@ -946,7 +946,7 @@ class StixCyberObservable(StixCyberObservableDeprecatedMixin):
                     ),
                 }
             elif type == "Windows-Registry-Value-Type":
-                input_variables["WindowsRegistryKeyValueType"] = {
+                input_variables["WindowsRegistryValueType"] = {
                     "name": (
                         observable_data["name"] if "name" in observable_data else None
                     ),


### PR DESCRIPTION
The input_variables name is wrong according to the GraphSQL queries

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
Fix the variable name
*

### Related issues

* closes: https://github.com/OpenCTI-Platform/client-python/issues/974
Created IOC type Windows-Registry-Value-Type
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [X] I consider the submitted work as finished
- [X] I tested the code for its functionality
- [] I wrote test cases for the relevant uses case
- [] I added/update the relevant documentation (either on github or on notion)
- [X] here necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
