### PR TITLE
[client]: unify empty state handling

### DIFF
--- a/pycti/connector/opencti_connector_helper.py
+++ b/pycti/connector/opencti_connector_helper.py
@@ -783,9 +783,10 @@ class ListenStream(threading.Thread):
                         # state can be None if reset from the UI
                         # In this case, default parameters will be used but SSE Client needs to be restarted
                         if state is None:
-                            self.exit = True
-                        state["start_from"] = str(msg.id)
-                        self.helper.set_state(state)
+                            self.exit_event.set()
+                        else:
+                            state["start_from"] = str(msg.id)
+                            self.helper.set_state(state)
         except Exception as ex:
             self.helper.connector_logger.error(
                 "Error in ListenStream loop, exit.", {"reason": str(ex)}


### PR DESCRIPTION
### Proposed changes

Original issue :
```
{
  "timestamp": "2025-08-12T14:52:15.286095Z", 
  "level": "ERROR", 
  "name": "Microsoft Sentinel", 
  "message": "Error in ListenStream loop, exit.", 
  "exc_info": "Traceback (most recent call last):
File \"/usr/local/lib/python3.12/site-packages/pycti/connector/opencti_connector_helper.py\", line 786, in run
    state[\"start_from\"] = str(msg.id)
    ~~~~^^^^^^^^^^^
TypeError: 'NoneType' object does not support item assignment", 
"attributes": {"reason": "'NoneType' object does not support item assignment"}}
```

In order to handle the reset of the state in the UI for stream connectors, this conditions had been implemented in the past : 
https://github.com/OpenCTI-Platform/client-python/commit/38fc5c45e06b9db7d890d1b3f5442cfb5e80bf89#diff-d5f76d595ba569b42f34c9cbf943833f0e132010315ed4680b7966f2ee961868R418-R422
```diff
+                        if state is None:
+                            self.exit = True
+                        else:
+                            state["start_from"] = str(msg.id)
+                            self.helper.set_state(state)
```

However, no else condition was added here :
https://github.com/OpenCTI-Platform/client-python/commit/38fc5c45e06b9db7d890d1b3f5442cfb5e80bf89#diff-d5f76d595ba569b42f34c9cbf943833f0e132010315ed4680b7966f2ee961868R428-R429
```diff
+                        if state is None:
+                            self.exit = True
```

Also, an error in the code had been fixed by this code :
https://github.com/OpenCTI-Platform/client-python/commit/2efa061be28118bc6fc3ddaa9eb2986e8163b722#diff-d5f76d595ba569b42f34c9cbf943833f0e132010315ed4680b7966f2ee961868L519
```diff
-                            self.exit = True
+                            self.exit_event.set()
```
And wasn't changed on L786

This Fix handle the NoneType error and fix the exit_event.set()


### Related issues

* https://github.com/OpenCTI-Platform/connectors/issues/4482

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
