### PR TITLE
[client] Grouping content is erased when approving Draft (#11874)

### DIFF
--- a/pycti/entities/opencti_case_rfi.py
+++ b/pycti/entities/opencti_case_rfi.py
@@ -701,6 +701,7 @@ class CaseRfi:
         created = kwargs.get("created", None)
         modified = kwargs.get("modified", None)
         name = kwargs.get("name", None)
+        content = kwargs.get("content", None)
         description = kwargs.get("description", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
         granted_refs = kwargs.get("objectOrganization", None)
@@ -742,6 +743,7 @@ class CaseRfi:
                         "modified": modified,
                         "name": name,
                         "description": description,
+                        "content": content,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
                         "x_opencti_workflow_id": x_opencti_workflow_id,
                         "update": update,
@@ -874,6 +876,13 @@ class CaseRfi:
                 stix_object["x_opencti_assignee_ids"] = (
                     self.opencti.get_attribute_in_extension("assignee_ids", stix_object)
                 )
+            if "x_opencti_content" not in stix_object or "content" not in stix_object:
+                stix_object["content"] = self.opencti.get_attribute_in_extension(
+                    "content", stix_object
+                )
+            if "x_opencti_content" in stix_object:
+                stix_object["content"] = stix_object["x_opencti_content"]
+
             if "x_opencti_participant_ids" not in stix_object:
                 stix_object["x_opencti_participant_ids"] = (
                     self.opencti.get_attribute_in_extension(
@@ -898,6 +907,11 @@ class CaseRfi:
                 externalReferences=(
                     extras["external_references_ids"]
                     if "external_references_ids" in extras
+                    else None
+                ),
+                content=(
+                    self.opencti.stix2.convert_markdown(stix_object["content"])
+                    if "content" in stix_object
                     else None
                 ),
                 revoked=stix_object["revoked"] if "revoked" in stix_object else None,

--- a/pycti/entities/opencti_case_rft.py
+++ b/pycti/entities/opencti_case_rft.py
@@ -697,6 +697,7 @@ class CaseRft:
         priority = kwargs.get("priority", None)
         confidence = kwargs.get("confidence", None)
         lang = kwargs.get("lang", None)
+        content = kwargs.get("content", None)
         created = kwargs.get("created", None)
         modified = kwargs.get("modified", None)
         name = kwargs.get("name", None)
@@ -735,6 +736,7 @@ class CaseRft:
                         "revoked": revoked,
                         "severity": severity,
                         "priority": priority,
+                        "content": content,
                         "confidence": confidence,
                         "lang": lang,
                         "created": created,
@@ -865,6 +867,13 @@ class CaseRft:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_content" not in stix_object or "content" not in stix_object:
+                stix_object["content"] = self.opencti.get_attribute_in_extension(
+                    "content", stix_object
+                )
+            if "x_opencti_content" in stix_object:
+                stix_object["content"] = stix_object["x_opencti_content"]
+
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
                     self.opencti.get_attribute_in_extension("workflow_id", stix_object)
@@ -903,6 +912,11 @@ class CaseRft:
                 priority=stix_object["priority"] if "priority" in stix_object else None,
                 confidence=(
                     stix_object["confidence"] if "confidence" in stix_object else None
+                ),
+                content=(
+                    self.opencti.stix2.convert_markdown(stix_object["content"])
+                    if "content" in stix_object
+                    else None
                 ),
                 lang=stix_object["lang"] if "lang" in stix_object else None,
                 created=stix_object["created"] if "created" in stix_object else None,

--- a/pycti/entities/opencti_grouping.py
+++ b/pycti/entities/opencti_grouping.py
@@ -644,6 +644,7 @@ class Grouping:
         modified = kwargs.get("modified", None)
         name = kwargs.get("name", None)
         context = kwargs.get("context", None)
+        content = kwargs.get("content", None)
         description = kwargs.get("description", None)
         x_opencti_aliases = kwargs.get("x_opencti_aliases", None)
         x_opencti_stix_ids = kwargs.get("x_opencti_stix_ids", None)
@@ -681,6 +682,7 @@ class Grouping:
                         "modified": modified,
                         "name": name,
                         "context": context,
+                        "content": content,
                         "description": description,
                         "x_opencti_aliases": x_opencti_aliases,
                         "x_opencti_stix_ids": x_opencti_stix_ids,
@@ -802,6 +804,13 @@ class Grouping:
                 stix_object["x_opencti_granted_refs"] = (
                     self.opencti.get_attribute_in_extension("granted_refs", stix_object)
                 )
+            if "x_opencti_content" not in stix_object or "content" not in stix_object:
+                stix_object["content"] = self.opencti.get_attribute_in_extension(
+                    "content", stix_object
+                )
+            if "x_opencti_content" in stix_object:
+                stix_object["content"] = stix_object["x_opencti_content"]
+
             if "x_opencti_workflow_id" not in stix_object:
                 stix_object["x_opencti_workflow_id"] = (
                     self.opencti.get_attribute_in_extension("workflow_id", stix_object)
@@ -824,6 +833,11 @@ class Grouping:
                 externalReferences=(
                     extras["external_references_ids"]
                     if "external_references_ids" in extras
+                    else None
+                ),
+                content=(
+                    self.opencti.stix2.convert_markdown(stix_object["content"])
+                    if "content" in stix_object
                     else None
                 ),
                 revoked=stix_object["revoked"] if "revoked" in stix_object else None,


### PR DESCRIPTION
### Proposed changes

* add missing content attribute at create & import for groupings, RFI & RFT

### Related issues

* https://github.com/OpenCTI-Platform/opencti/issues/11874